### PR TITLE
feat: validator with simple CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "@metaplex-foundation/amman",
   "version": "0.0.0",
   "description": "Borsh compatible De/Serializer",
-  "main": "dist/src/bors.js",
-  "types": "dist/src/amman.d.ts",
+  "main": "dist/amman.js",
+  "types": "dist/amman.d.ts",
+  "bin": {
+    "amman": "dist/cli/amman.js"
+  },
   "scripts": {
     "check:publish-ready": "yarn build",
     "preversion": "yarn check:publish-ready",
@@ -27,11 +30,14 @@
     "dist/src/*"
   ],
   "dependencies": {
-    "debug": "^4.3.3"
+    "@solana/web3.js": "^1.31.0",
+    "debug": "^4.3.3",
+    "wait-on": "^6.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/node": "^16.11.12",
+    "@types/wait-on": "^5.3.1",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "spok": "^1.4.2",

--- a/src/amman.ts
+++ b/src/amman.ts
@@ -1,1 +1,3 @@
-console.log('amman')
+export * from './validator'
+
+export { airdrop, tmpLedgerDir } from './utils'

--- a/src/cli/amman.ts
+++ b/src/cli/amman.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import path from 'path'
+import { initValidator } from '../validator'
+
+function help() {
+  return `
+amman <config.js>
+
+The config should be a JavaScript module exporting any of the below properties:
+
+  killRunningValidators   if true will kill any solana-test-validators currently running on the system.
+  programs                bpf programs which should be loaded into the test validator
+  jsonRpcUrl              the URL at which the test validator should listen for JSON RPC requests
+  websocketUrl            for the RPC websocket
+  ledgerDir               where the solana test validator writes the ledger
+  resetLedger             if true the ledger is reset to genesis at startup
+  verifyFees              if true the validator is not considered fully started up until it charges transaction fees
+`
+}
+
+const args = process.argv.slice(2)
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(help())
+  process.exit(0)
+}
+let configPath
+if (args.length === 0) {
+  console.error(
+    '\n  No config provided, using default config, run with `--help` for more info\n'
+  )
+} else {
+  configPath = path.resolve(args[0])
+}
+try {
+  const config = configPath != null ? require(configPath) : {}
+  initValidator(config)
+} catch (err: any) {
+  console.error(
+    `Having trouble loading amman config from ${args[0]} which resolved to ${configPath}`
+  )
+  console.error(err)
+  console.log(help())
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,32 @@
+import debug from 'debug'
+import { tmpdir } from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import { Connection, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js'
+
+export const LOCALHOST = 'http://127.0.0.1:8899/'
+
+export const logError = debug('amman:error')
+export const logInfo = debug('amman:info')
+export const logDebug = debug('amman:debug')
+export const logTrace = debug('amman:trace')
+
+export function tmpLedgerDir(testLabel = 'amman-ledger') {
+  return path.join(tmpdir(), testLabel)
+}
+
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+export function createHash(s: Buffer) {
+  return crypto.createHash('sha256').update(s).digest('hex')
+}
+
+export async function airdrop(
+  connection: Connection,
+  publicKey: PublicKey,
+  sol = 1
+) {
+  const sig = await connection.requestAirdrop(publicKey, sol * LAMPORTS_PER_SOL)
+  return connection.confirmTransaction(sig)
+}

--- a/src/validator/ensure-validator-up.ts
+++ b/src/validator/ensure-validator-up.ts
@@ -1,0 +1,62 @@
+import {
+  Connection,
+  Keypair,
+  SystemProgram,
+  Transaction,
+} from '@solana/web3.js'
+import { airdrop, logDebug } from '../utils'
+import waitOn from 'wait-on'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/*
+ * Right after a local test validator is started up it doesn't seem to charge
+ * fees at times.
+ * Here we make sure we don't consider it started up until it does charge fees.
+ */
+export async function ensureValidatorIsUp(
+  connectionURL: string,
+  verifyFees: boolean
+) {
+  logDebug('Waiting for validator to come up ...')
+  await waitOn({
+    resources: [connectionURL],
+    interval: 1000,
+    validateStatus: (status: number) => status === 405,
+    log: false,
+  })
+  if (verifyFees) {
+    logDebug('Ensuring validator charges fees ...')
+
+    const payer = Keypair.generate()
+    const connection = new Connection(connectionURL, 'confirmed')
+    await airdrop(connection, payer.publicKey, 200)
+    return ensureFees(connectionURL, payer)
+  }
+}
+
+async function ensureFees(
+  connectionURL: string,
+  payer: Keypair
+): Promise<void> {
+  const receiver = Keypair.generate()
+  const connection = new Connection(connectionURL, 'confirmed')
+  const transferIx = SystemProgram.transfer({
+    lamports: 1000,
+    fromPubkey: payer.publicKey,
+    toPubkey: receiver.publicKey,
+  })
+  const transaction = new Transaction().add(transferIx)
+  const recentBlockhash = (await connection.getRecentBlockhash('confirmed'))
+    .blockhash
+  transaction.recentBlockhash = recentBlockhash
+  const sig = await connection.sendTransaction(transaction, [payer])
+  await connection.confirmTransaction(sig)
+  const confirmedTx = await connection.getConfirmedTransaction(sig)
+
+  if (confirmedTx?.meta?.fee === 0) {
+    logDebug('Transaction completed without charging fees, trying again ...')
+    await sleep(2000)
+    return ensureFees(connectionURL, payer)
+  }
+}

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,0 +1,1 @@
+export * from './init-validator'

--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -1,0 +1,82 @@
+import { LOCALHOST, logInfo, logTrace, sleep, tmpLedgerDir } from '../utils'
+
+import { execSync as exec, spawn } from 'child_process'
+import { solanaConfig } from './prepare-config'
+import { ensureValidatorIsUp } from './ensure-validator-up'
+import { ValidatorConfig } from './types'
+
+const PIPE_VALIDATOR = process.env.PIPE_VALIDATOR != null
+
+export const DEFAULT_VALIDATOR_CONFIG: ValidatorConfig = {
+  killRunningValidators: true,
+  programs: [],
+  jsonRpcUrl: LOCALHOST,
+  websocketUrl: '',
+  commitment: 'confirmed',
+  ledgerDir: tmpLedgerDir(),
+  resetLedger: true,
+  verifyFees: false,
+}
+
+export async function initValidator(configArg: Partial<ValidatorConfig>) {
+  const {
+    killRunningValidators,
+    programs,
+    jsonRpcUrl,
+    websocketUrl,
+    commitment,
+    ledgerDir,
+    resetLedger,
+    verifyFees,
+  }: ValidatorConfig = { ...DEFAULT_VALIDATOR_CONFIG, ...configArg }
+
+  if (killRunningValidators) {
+    try {
+      exec('pkill solana-test-validator')
+      logInfo('Killed currently running solana-test-validator')
+      await sleep(1000)
+    } catch (err) {}
+  }
+
+  const { configPath, cleanupConfig } = await solanaConfig({
+    websocketUrl,
+    jsonRpcUrl,
+    commitment,
+  })
+
+  const args = ['-C', configPath, '--ledger', ledgerDir]
+  if (resetLedger) args.push('-r')
+
+  if (programs.length > 0) {
+    args.push('--bpf-program')
+    for (const { programId, deployPath } of programs) {
+      args.push(programId)
+      args.push(deployPath)
+    }
+  }
+
+  const cmd = `solana-test-validator ${args.join(' \\\n  ')}`
+  if (logTrace.enabled) {
+    logTrace('Launching validator with the following command')
+    console.log(cmd)
+  }
+
+  const child = spawn('solana-test-validator', args, {
+    detached: true,
+    stdio: PIPE_VALIDATOR ? 'inherit' : 'ignore',
+  })
+  child.unref()
+
+  logInfo(
+    'Spawning new solana-test-validator with programs predeployed and ledger at %s',
+    ledgerDir
+  )
+  logInfo(
+    'Rerun with `PIPE_VALIDATOR=1` to triage eventual validator startup issues'
+  )
+
+  await ensureValidatorIsUp(jsonRpcUrl, verifyFees)
+  await cleanupConfig()
+
+  logInfo('solana-test-validator is up')
+}

--- a/src/validator/prepare-config.ts
+++ b/src/validator/prepare-config.ts
@@ -1,0 +1,24 @@
+import { Commitment } from '@solana/web3.js'
+import { promises as fs } from 'fs'
+
+import { tmpdir } from 'os'
+import path from 'path'
+import { createHash } from '../utils'
+
+export async function solanaConfig(config: {
+  jsonRpcUrl: string
+  websocketUrl: string
+  commitment: Commitment
+}) {
+  const { jsonRpcUrl, websocketUrl, commitment } = config
+  const configText = `---
+json_rpc_url: "${jsonRpcUrl}"
+websocket_url: "${websocketUrl}"
+commitment: ${commitment} 
+`
+  const configHash = createHash(Buffer.from(configText))
+  const configPath = path.join(tmpdir(), `amman-config.${configHash}.yml`)
+  await fs.writeFile(configPath, configText, 'utf8')
+
+  return { configPath, cleanupConfig: () => fs.unlink(configPath) }
+}

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -1,0 +1,46 @@
+import { Commitment } from '@solana/web3.js'
+
+/**
+ * Definition of a bpf program which the test-validator loads at startup.
+ *
+ * @property programId the public key under which to deploy the program
+ *
+ * @property deployPath the path at which the program  `.so` file built via
+ * `cargo build-bpf`is located
+ */
+export type Program = {
+  programId: string
+  deployPath: string
+}
+
+/**
+ * Configures the solana-test-validator started up by amman.
+ *
+ * @property killRunningValidators if true will kill any solana-test-validators
+ * currently running on the system.
+ *
+ * @property programs array of {@link Program} which should be loaded into the
+ * test validator
+ *
+ * @property jsonRpcUrl the URL at which the test validator should listen for
+ * JSON RPC requests
+ *
+ * @property websocketUrl for the RPC websocket
+ *
+ * @property ledgerDir where the solana test validator writes the ledger
+ *
+ * @property resetLedger if `true` the ledger is reset to genesis at startup
+ *
+ * @property verifyFees if `true` the validator is not considered fully started
+ * up until it charges transaction fees
+ */
+export type ValidatorConfig = {
+  killRunningValidators: boolean
+  programs: Program[]
+  jsonRpcUrl: string
+  websocketUrl: string
+  commitment: Commitment
+  ledgerDir: string
+  resetLedger: boolean
+  verifyFees: boolean
+}


### PR DESCRIPTION
amman runs test validator according to provided JavaScript config.

**NOTE**: this is the initial implementation and the CLI will be improved with a proper tool
like `yargs` or similar in a subsequent PR.
