### PR TITLE
cli: adding validator command and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,74 @@
 **A** **m** odern **man** datory toolbelt to help test solana SDK libraries and apps on a locally
 running validator.
 
-LICENSE
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-MIT
+- [CLI](#cli)
+  - [Commands: validator](#commands-validator)
+    - [Sample Validator Config](#sample-validator-config)
+- [LICENSE](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## CLI
+
+```sh
+amman [command]
+
+Commands:
+  amman validator [config]  Launches a solana-test-validator
+
+Options:
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+``` 
+
+### Commands: validator
+
+```sh
+amman validator <config.js>
+```
+
+If no `config.js` is provided _amman_ looks for an `.ammanrc.js` file in the current directory.
+If that isn't found either it uses a default config.
+
+The config should be a JavaScript module exporting 'validator' with any of the below
+properties:
+
+- killRunningValidators: if true will kill any solana-test-validators currently running on the system.
+- programs: bpf programs which should be loaded into the test validator
+- jsonRpcUrl: the URL at which the test validator should listen for JSON RPC requests
+- websocketUrl: for the RPC websocket
+- ledgerDir: where the solana test validator writes the ledger
+- resetLedger: if true the ledger is reset to genesis at startup
+- verifyFees: if true the validator is not considered fully started up until it charges transaction fees
+
+#### Sample Validator Config
+
+Below is an example validator config with all values set to the defaults except for an added
+program.
+
+```js
+import { LOCALHOST, tmpLedgerDir } from 'amman'
+
+module.exports = {
+  validator: {
+    killRunningValidators: true,
+    programs: [
+      { programId: programIds.metadata, deployPath: localDeployPath('mpl_token_metadata') },
+    ],
+    jsonRpcUrl: LOCALHOST,
+    websocketUrl: '',
+    commitment: 'confirmed',
+    ledgerDir: tmpLedgerDir(),
+    resetLedger: true,
+    verifyFees: false,
+  }
+}
+```
+
+## LICENSE
+
+Apache 2.0

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "tape dist/test/*.test.js",
     "lint": "prettier -c ./src/",
     "lint:fix": "prettier --format ./src",
-    "doc": "typedoc src/*.ts --readme README.md"
+    "doc": "typedoc src/*.ts --readme README.md",
+    "doctoc": "doctoc README.md"
   },
   "repository": "git@github.com:metaplex-foundation/amman.git",
   "author": "Thorsten Lorenz <thlorenz@gmx.de>",
@@ -40,6 +41,7 @@
     "@types/node": "^16.11.12",
     "@types/wait-on": "^5.3.1",
     "@types/yargs": "^17.0.7",
+    "doctoc": "^2.1.0",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "spok": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
   "dependencies": {
     "@solana/web3.js": "^1.31.0",
     "debug": "^4.3.3",
-    "wait-on": "^6.0.0"
+    "wait-on": "^6.0.0",
+    "yargs": "^17.3.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/node": "^16.11.12",
     "@types/wait-on": "^5.3.1",
+    "@types/yargs": "^17.0.7",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "spok": "^1.4.2",

--- a/src/cli/amman.ts
+++ b/src/cli/amman.ts
@@ -1,44 +1,76 @@
 #!/usr/bin/env node
 
+import yargs from 'yargs/yargs'
+import { hideBin } from 'yargs/helpers'
 import path from 'path'
+import { logDebug, logInfo } from '../utils'
 import { initValidator } from '../validator'
 
-function help() {
-  return `
-amman <config.js>
+const commands = yargs(hideBin(process.argv)).command(
+  'validator [config]',
+  'Launches a solana-test-validator',
+  (args) => {
+    return args
+      .positional('config', {
+        describe: 'File containing config with `validator` property.',
+      })
+      .help('help', validatorHelp())
+  }
+)
 
-The config should be a JavaScript module exporting any of the below properties:
+const args = commands.parseSync()
 
-  killRunningValidators   if true will kill any solana-test-validators currently running on the system.
-  programs                bpf programs which should be loaded into the test validator
-  jsonRpcUrl              the URL at which the test validator should listen for JSON RPC requests
-  websocketUrl            for the RPC websocket
-  ledgerDir               where the solana test validator writes the ledger
-  resetLedger             if true the ledger is reset to genesis at startup
-  verifyFees              if true the validator is not considered fully started up until it charges transaction fees
-`
-}
-
-const args = process.argv.slice(2)
-if (args.includes('--help') || args.includes('-h')) {
-  console.log(help())
-  process.exit(0)
-}
-let configPath
-if (args.length === 0) {
-  console.error(
-    '\n  No config provided, using default config, run with `--help` for more info\n'
-  )
+if (args._.length === 0 || args._[0] !== 'validator') {
+  commands.showHelp()
 } else {
-  configPath = path.resolve(args[0])
+  const { config } = args as { config?: string }
+  let configPath
+  if (config == null) {
+    // TODO: try to find `.ammanrc.js` in PWD first
+    console.error(
+      '\n  No config provided, using default config, run with `--help` for more info\n'
+    )
+  } else {
+    configPath = path.resolve(config)
+  }
+  try {
+    const config = configPath != null ? require(configPath) : { validator: {} }
+    if (config.validator == null) {
+      console.error(`This config ${config} is missing a 'validator' property`)
+      process.exit(1)
+    }
+    logInfo(
+      `Running validator with ${config.validator.programs.length} custom program(s) preloaded`
+    )
+    logDebug(config.validator)
+    initValidator(config.validator)
+  } catch (err: any) {
+    console.error(err)
+    console.error(
+      `Having trouble loading amman config from ${config} which resolved to ${configPath}`
+    )
+    commands.showHelp()
+  }
 }
-try {
-  const config = configPath != null ? require(configPath) : {}
-  initValidator(config)
-} catch (err: any) {
-  console.error(
-    `Having trouble loading amman config from ${args[0]} which resolved to ${configPath}`
-  )
-  console.error(err)
-  console.log(help())
+
+function validatorHelp() {
+  return `
+amman validator <config.js>
+
+The config should be a JavaScript module exporting 'validator' with any of the below properties:
+
+killRunningValidators: if true will kill any solana-test-validators currently running on the system.
+
+programs: bpf programs which should be loaded into the test validator
+
+jsonRpcUrl: the URL at which the test validator should listen for JSON RPC requests
+
+websocketUrl: for the RPC websocket
+
+ledgerDir: where the solana test validator writes the ledger
+
+resetLedger: if true the ledger is reset to genesis at startup
+
+verifyFees: if true the validator is not considered fully started up until it charges transaction fees
+`
 }

--- a/src/cli/amman.ts
+++ b/src/cli/amman.ts
@@ -2,9 +2,11 @@
 
 import yargs from 'yargs/yargs'
 import { hideBin } from 'yargs/helpers'
-import path from 'path'
-import { logDebug, logInfo } from '../utils'
-import { initValidator } from '../validator'
+import {
+  handleValidatorCommand,
+  ValidatorCommandArgs,
+  validatorHelp,
+} from './commands'
 
 const commands = yargs(hideBin(process.argv)).command(
   'validator [config]',
@@ -18,59 +20,24 @@ const commands = yargs(hideBin(process.argv)).command(
   }
 )
 
-const args = commands.parseSync()
+async function main() {
+  const args = commands.parseSync()
 
-if (args._.length === 0 || args._[0] !== 'validator') {
-  commands.showHelp()
-} else {
-  const { config } = args as { config?: string }
-  let configPath
-  if (config == null) {
-    // TODO: try to find `.ammanrc.js` in PWD first
-    console.error(
-      '\n  No config provided, using default config, run with `--help` for more info\n'
-    )
-  } else {
-    configPath = path.resolve(config)
-  }
-  try {
-    const config = configPath != null ? require(configPath) : { validator: {} }
-    if (config.validator == null) {
-      console.error(`This config ${config} is missing a 'validator' property`)
-      process.exit(1)
-    }
-    logInfo(
-      `Running validator with ${config.validator.programs.length} custom program(s) preloaded`
-    )
-    logDebug(config.validator)
-    initValidator(config.validator)
-  } catch (err: any) {
-    console.error(err)
-    console.error(
-      `Having trouble loading amman config from ${config} which resolved to ${configPath}`
-    )
+  if (args._.length === 0 || args._[0] !== 'validator') {
     commands.showHelp()
+  } else {
+    const { needHelp } = await handleValidatorCommand(
+      args as ValidatorCommandArgs
+    )
+    if (needHelp) {
+      commands.showHelp()
+    }
   }
 }
 
-function validatorHelp() {
-  return `
-amman validator <config.js>
-
-The config should be a JavaScript module exporting 'validator' with any of the below properties:
-
-killRunningValidators: if true will kill any solana-test-validators currently running on the system.
-
-programs: bpf programs which should be loaded into the test validator
-
-jsonRpcUrl: the URL at which the test validator should listen for JSON RPC requests
-
-websocketUrl: for the RPC websocket
-
-ledgerDir: where the solana test validator writes the ledger
-
-resetLedger: if true the ledger is reset to genesis at startup
-
-verifyFees: if true the validator is not considered fully started up until it charges transaction fees
-`
-}
+main()
+  .then(() => process.exit(0))
+  .catch((err: any) => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,0 +1,1 @@
+export * from './validator'

--- a/src/cli/commands/validator.ts
+++ b/src/cli/commands/validator.ts
@@ -1,0 +1,62 @@
+import path from 'path'
+import { logDebug, logInfo } from '../../utils'
+import { initValidator } from '../../validator'
+
+export type ValidatorCommandArgs = {
+  config?: string
+}
+
+export async function handleValidatorCommand(args: ValidatorCommandArgs) {
+  let configPath
+
+  const { config } = args
+  if (config == null) {
+    // TODO: try to find `.ammanrc.js` in PWD first
+    console.error(
+      '\n  No config provided, using default config, run with `--help` for more info\n'
+    )
+  } else {
+    configPath = path.resolve(config)
+  }
+  try {
+    const config = configPath != null ? require(configPath) : { validator: {} }
+    if (config.validator == null) {
+      console.error(`This config ${config} is missing a 'validator' property`)
+      process.exit(1)
+    }
+    logInfo(
+      `Running validator with ${config.validator.programs.length} custom program(s) preloaded`
+    )
+    logDebug(config.validator)
+    await initValidator(config.validator)
+    return { needHelp: false }
+  } catch (err: any) {
+    console.error(err)
+    console.error(
+      `Having trouble loading amman config from ${config} which resolved to ${configPath}`
+    )
+    return { needHelp: true }
+  }
+}
+
+export function validatorHelp() {
+  return `
+amman validator <config.js>
+
+The config should be a JavaScript module exporting 'validator' with any of the below properties:
+
+killRunningValidators: if true will kill any solana-test-validators currently running on the system.
+
+programs: bpf programs which should be loaded into the test validator
+
+jsonRpcUrl: the URL at which the test validator should listen for JSON RPC requests
+
+websocketUrl: for the RPC websocket
+
+ledgerDir: where the solana test validator writes the ledger
+
+resetLedger: if true the ledger is reset to genesis at startup
+
+verifyFees: if true the validator is not considered fully started up until it charges transaction fees
+`
+}


### PR DESCRIPTION
To prep for added commands in the future normalized on `amman <cmd> [params]`.
Using `yargs` to add such a `validator` command.
Documented said command.

Also updated the config schema to contain `validator` prop for same command which also allows
the config to contain extra properties ignored by amman. This facilitates inheriting the config
and utils to build a custom config from a project wide base.

When no config is specified to `validator` amman will try to find it locally before falling
back to the default config.
