### PR TITLE
fix: put prefix --bpf-program before each of program's address

### DIFF
--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -54,8 +54,8 @@ export async function initValidator(configArg: Partial<ValidatorConfig>) {
   if (resetLedger) args.push('-r')
 
   if (programs.length > 0) {
-    args.push('--bpf-program')
     for (const { programId, deployPath } of programs) {
+      args.push('--bpf-program')
       args.push(programId)
       args.push(deployPath)
     }


### PR DESCRIPTION
- what does it fix: This pull request changes arguments that are passing to `solana-test-validator`, so option `--bpf-program` now is before `each` BPF program. 

Without these changes, `solana-test-validator` **will not run**, if we use several BPF programs