### PR TITLE
chore: change pkill's behavior

### DIFF
--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -38,7 +38,7 @@ export async function initValidator(configArg: Partial<ValidatorConfig>) {
 
   if (killRunningValidators) {
     try {
-      exec('pkill solana-test-validator')
+      exec('pkill -f solana-test-validator')
       logInfo('Killed currently running solana-test-validator')
       await sleep(1000)
     } catch (err) {}


### PR DESCRIPTION
On the Linux systems, command:  `pkill solana-test-validator` will not stop process with the name `solana-test-validator`,  instead of it we should use `pkill -f solana-test-validator`.

The reasons why it happens we can find in [pkill's documentation ](https://man7.org/linux/man-pages/man1/pkill.1.html)

```
NOTES  
 - The process name used for matching is limited to the 15
 characters present in the output of /proc/pid/stat.
 - Use the -f option to match against the complete command line,
 /proc/pid/cmdline.
```
So the length of `solana-test-validator` is 19, and  we should use `-f` option to kill the process
