### PR TITLE
feat: amman start launches without a config

### DIFF
--- a/src/cli/amman.ts
+++ b/src/cli/amman.ts
@@ -22,6 +22,9 @@ import { killRunningServer } from '../utils/http'
 import { AMMAN_STORAGE_PORT } from '../storage'
 
 const commands = yargs(hideBin(process.argv))
+  // -----------------
+  // start
+  // -----------------
   .command(
     'start',
     'Launches a solana-test-validator and the amman relay and/or mock storage if so configured',
@@ -30,14 +33,22 @@ const commands = yargs(hideBin(process.argv))
         .positional('config', {
           describe:
             'File containing config with `validator` property along with options for the relay and storage.',
+          type: 'string',
+          demandOption: false,
         })
         .help('help', startHelp())
     }
   )
+  // -----------------
+  // stop
+  // -----------------
   .command(
     'stop',
     'Stops the relay and storage and kills the running solana test validator'
   )
+  // -----------------
+  // airdrop
+  // -----------------
   .command('airdrop', 'Airdrops provided Sol to the payer', (args) =>
     args
       .positional('destination', {
@@ -65,9 +76,15 @@ const commands = yargs(hideBin(process.argv))
       })
       .help('help', airdropHelp())
   )
+  // -----------------
+  // label
+  // -----------------
   .command('label', 'Adds PublicKey labels to amman', (args) =>
     args.help('help', labelHelp())
   )
+  // -----------------
+  // account
+  // -----------------
   .command(
     'account',
     'Retrieves account information for a PublicKey or a label',
@@ -78,9 +95,12 @@ const commands = yargs(hideBin(process.argv))
         type: 'string',
       })
   )
+  // -----------------
+  // run
+  // -----------------
   .command(
     'run',
-    'Executes the provided command after expanding all address labels.',
+    'Executes the provided command after expanding all address labels',
     (args) => args.help('help', runHelp())
   )
 
@@ -94,6 +114,9 @@ async function main() {
   const command = cs[0]
 
   switch (command) {
+    // -----------------
+    // start
+    // -----------------
     case 'start': {
       const { needHelp } = await handleStartCommand(args as StartCommandArgs)
       if (needHelp) {
@@ -101,6 +124,9 @@ async function main() {
       }
       break
     }
+    // -----------------
+    // stop
+    // -----------------
     case 'stop': {
       await killRunningServer(AMMAN_RELAY_PORT)
       await killRunningServer(AMMAN_STORAGE_PORT)
@@ -111,6 +137,9 @@ async function main() {
       } catch (err) {}
       break
     }
+    // -----------------
+    // airdrop
+    // -----------------
     case 'airdrop': {
       const { commitment, label } = args
       try {
@@ -145,6 +174,9 @@ async function main() {
       })
       break
     }
+    // -----------------
+    // label
+    // -----------------
     case 'label': {
       const labels = cs.slice(1)
       assert(labels.length > 0, 'At least one label is required')
@@ -171,6 +203,9 @@ async function main() {
       })
       break
     }
+    // -----------------
+    // run
+    // -----------------
     case 'run': {
       const args = cs.slice(1)
       assert(
@@ -192,6 +227,6 @@ async function main() {
 }
 
 main().catch((err: any) => {
-  console.error(err)
+  logError(err)
   process.exit(1)
 })

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -1,11 +1,18 @@
 import path from 'path'
 import { logDebug, logInfo } from '../../utils'
 import { initValidator } from '../../validator'
+import { DEFAULT_VALIDATOR_CONFIG, initValidator } from '../../validator'
 import { AmmanConfig } from '../../types'
 import { canAccess } from '../../utils/fs'
+import { DEFAULT_RELAY_CONFIG } from '../../relay/types'
 
 export type StartCommandArgs = {
   config?: string
+}
+
+export const DEFAULT_START_CONFIG: AmmanConfig = {
+  validator: DEFAULT_VALIDATOR_CONFIG,
+  relay: DEFAULT_RELAY_CONFIG,
 }
 
 export async function handleStartCommand(args: StartCommandArgs) {
@@ -50,10 +57,10 @@ async function tryLoadLocalConfigRc() {
     logInfo('Found `.ammanrc.js` in current directory and using that as config')
     return { config, configPath }
   } else {
-    console.error(
-      '\n  No config provided nor an `.ammanrc.js` file found in current directory, using default config, run with `--help` for more info\n'
+    logInfo(
+      'No config provided nor `.ammanrc.js` found in current directory. Launching with default config.'
     )
-    return { config: { validator: {} }, configPath: null }
+    return { config: DEFAULT_START_CONFIG, configPath: null }
   }
 }
 

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -7,7 +7,7 @@ import {
   AmmanAccountProvider,
   AmmanAccountRendererMap,
 } from '../types'
-import { logDebug, logInfo, logTrace, safeJsonStringify } from '../utils'
+import { logDebug, logTrace, safeJsonStringify } from '../utils'
 import { killRunningServer } from '../utils/http'
 import {
   AMMAN_RELAY_PORT,
@@ -122,7 +122,7 @@ export class Relay {
       app.on('error', reject).listen(AMMAN_RELAY_PORT, () => {
         const addr = app.address() as AddressInfo
         const msg = `Amman Relay listening on ${addr.address}:${addr.port}`
-        logInfo(msg)
+        logDebug(msg)
         resolve({ app, io, relayServer })
       })
     })

--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -100,6 +100,9 @@ export async function initValidator(
     stdio: 'inherit',
   })
   child.unref()
+  await new Promise((resolve, reject) => {
+    child.on('spawn', resolve).on('error', reject)
+  })
 
   logInfo(
     'Spawning new solana-test-validator with programs predeployed and ledger at %s',


### PR DESCRIPTION
- chore: init validator awaits solana validator spawn
- feat: amman start no longer requires a config file
- chore: cleaning up logging
