### PR TITLE
logs: include instruction numbers and stabilize

### DIFF
--- a/src/cli/amman.ts
+++ b/src/cli/amman.ts
@@ -161,7 +161,6 @@ async function main() {
     // start
     // -----------------
     case 'start': {
-      process.on('SIGINT', stopAmman).on('SIGHUP', stopAmman)
       const { needHelp } = await handleStartCommand(args as StartCommandArgs)
       if (needHelp) {
         commands.showHelp()

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -1,6 +1,6 @@
-import { cliAmmanInstance } from '../utils'
+import { maybeAmmanInstance } from '../utils'
 import { pipeSolanaLogs } from '../utils/solana-logs'
 
 export function handleLogsCommand() {
-  return pipeSolanaLogs(cliAmmanInstance())
+  return pipeSolanaLogs(maybeAmmanInstance())
 }

--- a/src/cli/utils/resolvers.ts
+++ b/src/cli/utils/resolvers.ts
@@ -1,10 +1,20 @@
 import { Amman } from '../../api'
-import { isValidPublicKeyAddress } from '../../utils'
+import { isValidPublicKeyAddress, logTrace } from '../../utils'
 
 export function cliAmmanInstance() {
   return Amman.instance({
     ammanClientOpts: { autoUnref: false, ack: true },
   })
+}
+
+export function maybeAmmanInstance() {
+  try {
+    return Amman.instance({
+      ammanClientOpts: { autoUnref: false, ack: true },
+    })
+  } catch (_) {
+    logTrace('Amman instance not connected')
+  }
 }
 
 export async function resolveAccountAddresses(

--- a/src/cli/utils/solana-logs.ts
+++ b/src/cli/utils/solana-logs.ts
@@ -4,7 +4,7 @@ import { Cluster, LogMessage, PrettyLogger } from '../../diagnostics/programs'
 import colors from 'ansi-colors'
 import { Amman } from '../../api'
 
-export async function pipeSolanaLogs(amman: Amman) {
+export async function pipeSolanaLogs(amman?: Amman) {
   const logger = new PrettyLogger(amman)
   const child = spawn('solana', ['logs'], {
     detached: false,

--- a/src/cli/utils/solana-logs.ts
+++ b/src/cli/utils/solana-logs.ts
@@ -3,6 +3,7 @@ import split from 'split2'
 import { Cluster, LogMessage, PrettyLogger } from '../../diagnostics/programs'
 import colors from 'ansi-colors'
 import { Amman } from '../../api'
+import { logTrace } from '../../utils'
 
 export async function pipeSolanaLogs(amman?: Amman) {
   const logger = new PrettyLogger(amman)
@@ -11,7 +12,11 @@ export async function pipeSolanaLogs(amman?: Amman) {
     stdio: 'pipe',
   })
   for await (const line of child.stdout?.pipe(split())) {
-    await logLine(logger, line)
+    try {
+      await logLine(logger, line)
+    } catch (err) {
+      logTrace('Logger encountered an error', err)
+    }
   }
 }
 

--- a/src/cli/utils/solana-logs.ts
+++ b/src/cli/utils/solana-logs.ts
@@ -26,7 +26,11 @@ async function logLine(logger: PrettyLogger, line: string) {
   }
   for (const log of newLogs) {
     const color = styleToColor(log.style)
-    console.log(`${colors.dim(log.prefix)}${color(log.text)}`)
+    const count =
+      log.count != null
+        ? colors.bgGreen(colors.black(`#${log.count.join('.')} `)) + ' '
+        : ''
+    console.log(`${colors.dim(log.prefix)}${count}${color(log.text)}`)
   }
 }
 

--- a/src/diagnostics/programs/log-parser.ts
+++ b/src/diagnostics/programs/log-parser.ts
@@ -23,7 +23,7 @@ export class PrettyLogger {
   instructionCount: number[] = []
   depth: number = 0
 
-  constructor(readonly amman: Amman) {}
+  constructor(readonly amman?: Amman) {}
 
   private incDepth() {
     this.depth++
@@ -184,9 +184,10 @@ export class PrettyLogger {
   async prettyProgramLabel(programAddress: string, cluster: Cluster) {
     const programName = programLabel(programAddress, cluster)
     if (programName != null) return programName
-    const resolvedProgramName = await this.amman.addr.resolveRemoteAddress(
-      programAddress
-    )
+    const resolvedProgramName =
+      this.amman != null
+        ? await this.amman.addr.resolveRemoteAddress(programAddress)
+        : null
     return resolvedProgramName ?? `Unknown (${programAddress}) Program`
   }
 }

--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -96,7 +96,7 @@ export async function initValidator(
   }
 
   const child = spawn('solana-test-validator', args, {
-    detached: true,
+    detached: false,
     stdio: 'inherit',
   })
   child.unref()


### PR DESCRIPTION
Aside from the logger changes this also keeps `solana-test-validator` process attached so it gets killed when quitting amman.