### PR TITLE
chore: ci support by launching dev helpers selectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ import { LOCALHOST, tmpLedgerDir } from '@metaplex-foundation/amman'
 module.exports = {
   validator: {
     killRunningValidators: true,
-    launchExplorerRelay: process.env.CI == null,
     programs: [
       { 
         label: 'Token Metadata Program',
@@ -95,12 +94,14 @@ module.exports = {
     ledgerDir: tmpLedgerDir(),
     resetLedger: true,
     verifyFees: false,
+    detached: process.env.CI != null,
   },
   relay: {
+    enabled: process.env.CI == null,
     killlRunningRelay: true,
   },
   storage: {
-    enabled: process.env.CI == null && process.env.NO_STORAGE == null,
+    enabled: process.env.CI == null,
     storageId: 'mock-storage',
     clearOnStart: true,
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@lorisleiva/js-next-alpha": "^0.3.0",
+    "@metaplex-foundation/js-next": "^0.5.0",
     "@metaplex-foundation/cusper": "^0.0.2",
     "@solana/spl-token": "^0.2.0",
     "@solana/spl-token-registry": "^0.2.2405",

--- a/src/amman.browser.ts
+++ b/src/amman.browser.ts
@@ -2,7 +2,7 @@
  * Amman is not meant to be used in the browser, but we need to share some constants and types that
  * are needed to integrate the amman-explorer witht he backend.
  */
-export { LOCALHOST } from './utils'
+export { LOCALHOST, identifySolanaAddress } from './utils'
 export * from './types'
 export * from './relay/consts'
 export * from './relay/types'

--- a/src/amman.ts
+++ b/src/amman.ts
@@ -1,4 +1,4 @@
-export { tmpLedgerDir, LOCALHOST } from './utils'
+export { tmpLedgerDir, LOCALHOST, identifySolanaAddress } from './utils'
 export * from './api'
 export * from './asserts'
 export * from './diagnostics'

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -14,7 +14,7 @@ export type StartCommandArgs = {
 export const DEFAULT_START_CONFIG: AmmanConfig = {
   validator: DEFAULT_VALIDATOR_CONFIG,
   relay: DEFAULT_RELAY_CONFIG,
-  streamTransactionLogs: true,
+  streamTransactionLogs: process.env.CI == null,
 }
 
 export async function handleStartCommand(args: StartCommandArgs) {

--- a/src/relay/types.ts
+++ b/src/relay/types.ts
@@ -6,6 +6,7 @@ import { AmmanAccountProvider, AmmanAccountRendererMap } from '../types'
  * @category config
  */
 export const DEFAULT_RELAY_CONFIG: RelayConfig = {
+  enabled: process.env.CI == null,
   killRunningRelay: true,
   accountProviders: {},
   accountRenderers: new Map(),
@@ -14,9 +15,19 @@ export const DEFAULT_RELAY_CONFIG: RelayConfig = {
 /**
  * Configures the Amman Relay
  *
+ * @property enabled if true an amman-explorer relay is launched alongside the
+ * validator
+ * @property killRunningRelay if true an existing running relays are killed at
+ * start
+ * @property accountProviders a map of account providers which the relay uses
+ * to deserialize account data
+ * @property accountRenderers a map of account providers which the relay uses
+ * to custom render account data
+ *
  * @category config
  */
 export type RelayConfig = {
+  enabled: boolean
   killRunningRelay: boolean
   accountProviders: Record<string, AmmanAccountProvider>
   accountRenderers: AmmanAccountRendererMap

--- a/src/storage/mock-driver.ts
+++ b/src/storage/mock-driver.ts
@@ -3,7 +3,8 @@ import {
   Metaplex,
   MetaplexFile,
   MetaplexPlugin,
-} from '@lorisleiva/js-next-alpha'
+  SolAmount,
+} from '@metaplex-foundation/js-next'
 
 import { strict as assert } from 'assert'
 import BN from 'bn.js'
@@ -97,8 +98,10 @@ export class AmmanMockStorageDriver extends StorageDriver {
   static readonly getStorageUri = (storageId: string) =>
     `${AMMAN_STORAGE_URI}/${storageId}`
 
-  public async getPrice(file: MetaplexFile): Promise<BN> {
-    return new BN(file.buffer.byteLength).mul(this.costPerByte)
+  public async getPrice(file: MetaplexFile): Promise<SolAmount> {
+    return SolAmount.fromLamports(
+      new BN(file.buffer.byteLength).mul(this.costPerByte)
+    )
   }
 
   public async upload(file: MetaplexFile): Promise<string> {

--- a/src/storage/mock-server.ts
+++ b/src/storage/mock-server.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import { AMMAN_STORAGE_PORT, AMMAN_STORAGE_ROOT, StorageConfig } from '.'
 import { logDebug, logError, logTrace } from '../utils'
 import { canRead, ensureDirCleaned, ensureDirSync } from '../utils/fs'
-import { DefaultStorageConfig } from './types'
+import { DEFAULT_STORAGE_CONFIG } from './types'
 
 export class MockStorageServer {
   server?: Server
@@ -20,7 +20,7 @@ export class MockStorageServer {
   static async createInstance(storageConfig: StorageConfig) {
     if (MockStorageServer._instance == null) {
       const { storageId, clearOnStart } = {
-        ...DefaultStorageConfig,
+        ...DEFAULT_STORAGE_CONFIG,
         ...storageConfig,
       }
       const storageDir = path.join(AMMAN_STORAGE_ROOT, storageId)

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -26,7 +26,7 @@ export type StorageConfig = {
  *
  * @category config
  */
-export const DefaultStorageConfig: Omit<StorageConfig, 'storageId'> = {
+export const DEFAULT_STORAGE_CONFIG: Omit<StorageConfig, 'storageId'> = {
   enabled: process.env.CI == null,
   clearOnStart: true,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,15 @@ import { RelayConfig } from './relay/types'
 import { StorageConfig } from './storage'
 import { ValidatorConfig } from './validator/types'
 
+/**
+ * Amman Config
+ *
+ * @property validatorConfig Validator configuration
+ * @property relayConfig Relay configuration
+ * @property storageConfig Mock Storage configuration
+ * @property streamTransactionLogs if `true` the `solana logs` command is
+ * spawned and its output piped through a prettifier, defaults to run except when in a CI environment
+ */
 export type AmmanConfig = {
   validator?: ValidatorConfig
   relay?: RelayConfig

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -47,10 +47,14 @@ export function extractSolanaAddresses(text: string): Address[] {
 
   return matches
     .slice(0)
-    .map((m) => {
-      if (m.length <= 44) return { type: 'publicKey', value: m }
-      if (m.length >= 87) return { type: 'signature', value: m }
-      return null
-    })
+    .map(identifySolanaAddress)
     .filter((x) => x != null) as Address[]
+}
+
+export function identifySolanaAddress(maybeAddress: string): Address | null {
+  if (maybeAddress.length <= 44)
+    return { type: 'publicKey', value: maybeAddress }
+  if (maybeAddress.length >= 87)
+    return { type: 'signature', value: maybeAddress }
+  return null
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -78,7 +78,7 @@ export async function keypairFromFile(fullPath: string): Promise<Keypair> {
 /** @private */
 export async function ensureDirCleaned(dir: string) {
   if (!canRead(dir)) return
-  return fs.promises.rmdir(dir, { recursive: true })
+  return fs.promises.rm(dir, { recursive: true })
 }
 
 /** @private */

--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -34,6 +34,7 @@ export const DEFAULT_VALIDATOR_CONFIG: ValidatorConfig = {
   resetLedger: true,
   limitLedgerSize: 1e4,
   verifyFees: false,
+  detached: process.env.CI != null,
 }
 
 /**
@@ -54,6 +55,7 @@ export async function initValidator(
     resetLedger,
     limitLedgerSize,
     verifyFees,
+    detached,
   }: ValidatorConfig = { ...DEFAULT_VALIDATOR_CONFIG, ...validatorConfig }
   const {
     killRunningRelay,
@@ -98,7 +100,7 @@ export async function initValidator(
   }
 
   const child = spawn('solana-test-validator', args, {
-    detached: false,
+    detached,
     stdio: 'inherit',
   })
   child.unref()

--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -26,7 +26,6 @@ import {
  */
 export const DEFAULT_VALIDATOR_CONFIG: ValidatorConfig = {
   killRunningValidators: true,
-  launchExplorerRelay: process.env.CI == null,
   programs: [],
   jsonRpcUrl: LOCALHOST,
   websocketUrl: '',
@@ -55,13 +54,16 @@ export async function initValidator(
     resetLedger,
     limitLedgerSize,
     verifyFees,
-    launchExplorerRelay,
   }: ValidatorConfig = { ...DEFAULT_VALIDATOR_CONFIG, ...validatorConfig }
-  const { killRunningRelay, accountProviders, accountRenderers }: RelayConfig =
-    {
-      ...DEFAULT_RELAY_CONFIG,
-      ...relayConfig,
-    }
+  const {
+    killRunningRelay,
+    accountProviders,
+    accountRenderers,
+    enabled: relayEnabled,
+  }: RelayConfig = {
+    ...DEFAULT_RELAY_CONFIG,
+    ...relayConfig,
+  }
 
   if (killRunningValidators) {
     try {
@@ -110,7 +112,7 @@ export async function initValidator(
   )
 
   // Launch relay server in parallel
-  if (launchExplorerRelay) {
+  if (relayEnabled) {
     Relay.startServer(
       accountProviders,
       accountRenderers,

--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -17,6 +17,7 @@ import { Relay } from '../relay/server'
 import { DEFAULT_RELAY_CONFIG, RelayConfig } from '../relay/types'
 import {
   AMMAN_STORAGE_PORT,
+  DEFAULT_STORAGE_CONFIG,
   MockStorageServer,
   StorageConfig,
 } from '../storage'
@@ -132,7 +133,11 @@ export async function initValidator(
   }
 
   // Launch Storage server in parallel as well
-  if (storageConfig != null && storageConfig.enabled) {
+  const storageEnabled =
+    storageConfig != null &&
+    { ...DEFAULT_STORAGE_CONFIG, ...storageConfig }.enabled
+
+  if (storageEnabled) {
     killRunningServer(AMMAN_STORAGE_PORT)
       .then(() =>
         MockStorageServer.createInstance(storageConfig).then((storage) =>

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -21,9 +21,6 @@ export type Program = {
  * @property killRunningValidators if true will kill any solana-test-validators
  * currently running on the system.
  *
- * @property launchExplorerRelay if true an amman-explorer relay is launched
- * alongside the validator
- *
  * @property programs array of {@link Program} which should be loaded into the
  * test validator
  *
@@ -43,7 +40,6 @@ export type Program = {
  */
 export type ValidatorConfig = {
   killRunningValidators: boolean
-  launchExplorerRelay: boolean
   programs: Program[]
   jsonRpcUrl: string
   websocketUrl: string

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -37,6 +37,10 @@ export type Program = {
  *
  * @property verifyFees if `true` the validator is not considered fully started
  * up until it charges transaction fees
+ *
+ * @property detached if `true` the `solana-test-validator` will run detached
+ * which allows `amman` to exit while the validator keeps running. This
+ * defaults to `true` when run in CI.
  */
 export type ValidatorConfig = {
   killRunningValidators: boolean
@@ -48,4 +52,5 @@ export type ValidatorConfig = {
   resetLedger: boolean
   limitLedgerSize: number
   verifyFees: boolean
+  detached: boolean
 }


### PR DESCRIPTION
- util: expose identifySolanaAddress function
- deps: using metaplex foundation js-next 0.5
- relay: enabled part of relay config
- start: adapting config to be able to terminate in CI
- chore: adapt to Node.js 16
- storage: ensure it runs when not in CI env by default
