### PR TITLE
Fix: local accounts label and error handling

### DIFF
--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -32,7 +32,7 @@ class RelayServer {
     readonly accountProvider: AccountProvider,
     readonly accountStates: AccountStates,
     // Keyed pubkey:label
-    private readonly allKnownLabels: Record<string, string> = {},
+    private readonly allKnownLabels: Record<string, string> = {}
   ) {
     this.hookConnectionEvents()
   }
@@ -41,7 +41,7 @@ class RelayServer {
     this.io.on('connection', (socket) => {
       const client = `${socket.id} from ${socket.client.conn.remoteAddress}`
       socket.on('disconnect', () =>
-        logTrace(`socket.io ${client} disconnected`),
+        logTrace(`socket.io ${client} disconnected`)
       )
       logTrace(`socket.io ${client} connected`)
       this.hookMessages(socket)
@@ -91,7 +91,7 @@ export class Relay {
   private static createApp(
     accountProvider: AccountProvider,
     accountStates: AccountStates,
-    knownLabels: Record<string, string>,
+    knownLabels: Record<string, string>
   ) {
     const server = createServer()
     const io = new Server(server, {
@@ -103,7 +103,7 @@ export class Relay {
       io,
       accountProvider,
       accountStates,
-      knownLabels,
+      knownLabels
     )
     return { app: server, io, relayServer }
   }
@@ -113,7 +113,7 @@ export class Relay {
     accountRenderers: AmmanAccountRendererMap,
     programs: Program[],
     accounts: Account[],
-    killRunning: boolean = true,
+    killRunning: boolean = true
   ): Promise<{
     app: HttpServer
     io: Server
@@ -124,7 +124,7 @@ export class Relay {
     }
     const accountProvider = AccountProvider.fromRecord(
       accountProviders,
-      accountRenderers,
+      accountRenderers
     )
     AccountStates.createInstance(accountProvider.connection, accountProvider)
 
@@ -147,7 +147,7 @@ export class Relay {
     const { app, io, relayServer } = this.createApp(
       accountProvider,
       AccountStates.instance,
-      knownLabels,
+      knownLabels
     )
     return new Promise((resolve, reject) => {
       app.on('error', reject).listen(AMMAN_RELAY_PORT, () => {

--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -120,11 +120,17 @@ export async function initValidator(
       accountsFolder,
       forceClone
     )
-    for (const { accountId, executable } of accounts) {
-      args.push('--account')
-      args.push(accountId)
-      args.push(path.join(accountsFolder, `${accountId}.json`))
-
+    for (const { accountId, executable, cluster } of accounts) {
+      const accountPath = path.join(accountsFolder, `${accountId}.json`)
+      if (await canAccess(accountPath)) {
+        args.push('--account')
+        args.push(accountId)
+        args.push(accountPath)
+      } else {
+        throw new Error(
+          `Can't find account info file for account ${accountId} cloned from cluster ${cluster ?? accountsCluster}! \nMake sure the account exists on that cluster and try again.`
+        )
+      }
       if (executable) {
         const executableId = await getExecutableAddress(accountId)
         const executablePath = path.join(accountsFolder, `${executableId}.json`)
@@ -168,6 +174,7 @@ export async function initValidator(
       accountProviders,
       accountRenderers,
       programs,
+      accounts,
       killRunningRelay
     )
       .then(({ app }) => {

--- a/src/validator/init-validator.ts
+++ b/src/validator/init-validator.ts
@@ -128,7 +128,9 @@ export async function initValidator(
         args.push(accountPath)
       } else {
         throw new Error(
-          `Can't find account info file for account ${accountId} cloned from cluster ${cluster ?? accountsCluster}! \nMake sure the account exists on that cluster and try again.`
+          `Can't find account info file for account ${accountId} cloned from cluster ${
+            cluster ?? accountsCluster
+          }! \nMake sure the account exists on that cluster and try again.`
         )
       }
       if (executable) {


### PR DESCRIPTION
- Added error handling for when user tries to clone an account that doesn't exist
- Modifies the label logic to label cloned accounts (regression from programs -> accounts rename)