### PR TITLE
feat: modify accounts

### DIFF
--- a/amman-client/src/amman-client.ts
+++ b/amman-client/src/amman-client.ts
@@ -3,6 +3,7 @@ export * from './consts'
 export * from './types'
 
 export * from './asserts/api'
+export * from './assets/api'
 export * from './diagnostics/api'
 export * from './relay/api'
 export * from './storage/api'

--- a/amman-client/src/api.ts
+++ b/amman-client/src/api.ts
@@ -158,15 +158,16 @@ export class Amman {
 
   /**
    * Provides a {@link TransactionHandler} which uses the {@link payer} to sign transactions.
-   * @catetory transactions
+   * @category transactions
    */
   payerTransactionHandler(
     connection: Connection,
     payer: Keypair,
     errorResolver?: ErrorResolver
   ) {
-    this.addr.storeKeypair(payer, 'payer')
-    this.addr.addLabelIfUnknown('payer', payer.publicKey)
+    this.addr
+      .storeKeypair(payer, 'payer')
+      .then((label) => this.addr.addLabelIfUnknown('payer', label ?? 'payer'))
     return new PayerTransactionHandler(
       connection,
       payer,
@@ -177,8 +178,8 @@ export class Amman {
   /**
    * If you cannot use the {@link payerTransactionHandler} then you can use this to verify
    * the outcome of your transactions.
-   * @catetory transactions
-   * @catetory asserts
+   * @category transactions
+   * @category asserts
    */
   transactionChecker(connection: Connection, errorResolver?: ErrorResolver) {
     return new TransactionChecker(

--- a/amman-client/src/api.ts
+++ b/amman-client/src/api.ts
@@ -5,7 +5,8 @@ import {
   LAMPORTS_PER_SOL,
   PublicKey,
 } from '@solana/web3.js'
-import { AccountDataMutator, MutableAccount } from './assets/persistence'
+import { AccountDataSerializer } from './assets/account-data-serializer'
+import { MutableAccount } from './assets/persistence'
 import {
   AddressLabels,
   GenKeypair,
@@ -191,13 +192,13 @@ export class Amman {
   // -----------------
   accountModifier<T>(
     address: PublicKey,
-    dataMutator?: AccountDataMutator<T>,
+    serializer?: AccountDataSerializer<T>,
     connection?: Connection
   ) {
     return MutableAccount.from(
       this.ammanClient.requestSetAccount.bind(this.ammanClient),
       address,
-      dataMutator,
+      serializer,
       connection
     )
   }

--- a/amman-client/src/assets/account-data-serializer.ts
+++ b/amman-client/src/assets/account-data-serializer.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from 'assert'
+
+export type SerializeAccountData<T> = (data: T) => [Buffer, number] | Buffer
+export type DeserializeAccountData<T> = (
+  buf: Buffer,
+  offset?: number
+) => [T, number] | T
+
+export type PlainAccountDataSerializer<T> = {
+  serialize: SerializeAccountData<T>
+  deserialize: DeserializeAccountData<T>
+}
+export type FromArgsAccountDataSerializer<T> = {
+  fromArgs(args: T): { serialize: SerializeAccountData<T> }
+  deserialize: DeserializeAccountData<T>
+}
+
+function isPlainAccountDataSerializer<T>(
+  serializer: PlainAccountDataSerializer<T> | FromArgsAccountDataSerializer<T>
+): serializer is PlainAccountDataSerializer<T> {
+  return (
+    typeof (serializer as PlainAccountDataSerializer<T>).serialize ===
+    'function'
+  )
+}
+
+function isFromArgsAccountDataSerializer<T>(
+  serializer: PlainAccountDataSerializer<T> | FromArgsAccountDataSerializer<T>
+): serializer is FromArgsAccountDataSerializer<T> {
+  return (
+    typeof (serializer as FromArgsAccountDataSerializer<T>).fromArgs ===
+    'function'
+  )
+}
+
+export type AccountDataSerializer<T> =
+  | PlainAccountDataSerializer<T>
+  | FromArgsAccountDataSerializer<T>
+
+export function serializeData<T>(
+  serializer: AccountDataSerializer<T>,
+  data: T
+) {
+  if (isPlainAccountDataSerializer(serializer)) {
+    return serializer.serialize(data)
+  } else if (isFromArgsAccountDataSerializer(serializer)) {
+    return serializer.fromArgs(data).serialize(data)
+  }
+  assert.fail('Serializer needs to have serialize or fromArgs method')
+}

--- a/amman-client/src/assets/api.ts
+++ b/amman-client/src/assets/api.ts
@@ -1,1 +1,2 @@
+export { AccountDataSerializer } from './account-data-serializer'
 export * from './persistence'

--- a/amman-client/src/assets/api.ts
+++ b/amman-client/src/assets/api.ts
@@ -1,0 +1,1 @@
+export * from './persistence'

--- a/amman-client/src/assets/persistence.ts
+++ b/amman-client/src/assets/persistence.ts
@@ -53,11 +53,18 @@ export class MutableAccount<T> {
   }
 
   setOwner(owner: PublicKey) {
+    logTrace('Updating owner of [%s] %s -> %s', this.owner, owner)
     this.owner = owner.toBase58()
     return this
   }
 
   setLamports(lamports: number) {
+    logTrace(
+      'Updating lamports of [%s] %d -> %d',
+      this.pubkey,
+      this.lamports,
+      lamports
+    )
     this.lamports = lamports
     return this
   }
@@ -71,6 +78,12 @@ export class MutableAccount<T> {
     const updated = { ...state, ...dataUpdate }
 
     this.data = this.mutator.serialize(updated)[0]
+    logTrace(
+      'Updating data of [%s] to %O (%s)',
+      this.pubkey,
+      updated,
+      this.data.toString('base64')
+    )
     return this
   }
 

--- a/amman-client/src/assets/persistence.ts
+++ b/amman-client/src/assets/persistence.ts
@@ -1,0 +1,123 @@
+import { Connection, PublicKey } from '@solana/web3.js'
+import { strict as assert } from 'assert'
+import { LOCALHOST } from '../consts'
+import { scopedLog } from '../utils/log'
+
+const { logDebug, logTrace } = scopedLog('persist')
+
+export type PersistedAccountInfo = {
+  pubkey: string
+  account: {
+    lamports: number
+    data: [string, 'base64']
+    owner: string
+    executable: boolean
+    rentEpoch: number
+  }
+}
+
+export type AccountDataMutator<T> = {
+  serialize(data: T): [Buffer, number]
+  deserialize(buf: Buffer, offset?: number): [T, number]
+}
+
+export type PersistAccount = (
+  accountInfo: PersistedAccountInfo
+) => Promise<void>
+
+export class MutableAccount<T> {
+  private lamports: number
+  private data: Buffer
+  private owner: string
+  private executable: boolean
+  private rentEpoch: number
+
+  private constructor(
+    private readonly persist: PersistAccount,
+    readonly pubkey: string,
+    account: {
+      lamports: number
+      data: Buffer
+      owner: string
+      executable: boolean
+      rentEpoch: number
+    },
+    private readonly mutator?: AccountDataMutator<T>
+  ) {
+    this.pubkey = pubkey
+    this.lamports = account.lamports
+    this.data = account.data
+    this.owner = account.owner
+    this.executable = account.executable
+    this.rentEpoch = account.rentEpoch
+  }
+
+  setOwner(owner: PublicKey) {
+    this.owner = owner.toBase58()
+    return this
+  }
+
+  setLamports(lamports: number) {
+    this.lamports = lamports
+    return this
+  }
+
+  updateData<T>(dataUpdate: Partial<T>) {
+    assert(
+      this.mutator != null,
+      'Account data mutator is not defined, but needed to update account data'
+    )
+    const [state] = this.mutator.deserialize(this.data)
+    const updated = { ...state, ...dataUpdate }
+
+    this.data = this.mutator.serialize(updated)[0]
+    return this
+  }
+
+  commit() {
+    const accountInfo = this._toPersistedAccountInfo()
+    logDebug('Persisting account', accountInfo.pubkey)
+    logTrace(accountInfo)
+    return this.persist(accountInfo)
+  }
+
+  private _toPersistedAccountInfo(): PersistedAccountInfo {
+    return {
+      pubkey: this.pubkey,
+      account: {
+        lamports: this.lamports,
+        data: [this.data.toString('base64'), 'base64'],
+        owner: this.owner,
+        executable: this.executable,
+        rentEpoch: this.rentEpoch,
+      },
+    }
+  }
+
+  /** @private */
+  static async from<T>(
+    persist: PersistAccount,
+    address: PublicKey,
+    dataMutator?: AccountDataMutator<T>,
+    connection: Connection = new Connection(LOCALHOST, 'confirmed')
+  ) {
+    const accountInfo = await connection.getAccountInfo(address, 'confirmed')
+    assert(
+      accountInfo != null,
+      `Could not find account at '${address}' and thus cannot mutate it`
+    )
+
+    return new MutableAccount(
+      persist,
+      address.toBase58(),
+      {
+        lamports: accountInfo.lamports,
+        data: accountInfo.data,
+        owner: accountInfo.owner.toBase58(),
+        rentEpoch: accountInfo.rentEpoch ?? 0,
+        executable: accountInfo.executable,
+      },
+      dataMutator
+    )
+  }
+}

--- a/amman-client/src/diagnostics/address-labels.ts
+++ b/amman-client/src/diagnostics/address-labels.ts
@@ -8,8 +8,10 @@ import {
   isValidSolanaAddress,
 } from '../utils/address'
 import { KeyLike, isKeyLike, publicKeyString } from '../utils/keys'
-import { logError } from '../utils/log'
+import { logError, scopedLog } from '../utils/log'
 import { mapLabel } from './address-label-mapper'
+
+const { logTrace } = scopedLog('addr')
 
 /** @private */
 export type AddLabel = (
@@ -87,6 +89,7 @@ export class AddressLabels {
     this.knownLabels[keyString] = label
 
     await this.ammanClient.addAddressLabels({ [keyString]: label })
+    logTrace(`🔑 ${label}: ${keyString}`)
     return label
   }
 
@@ -112,6 +115,7 @@ export class AddressLabels {
             labels[keyString] = label
             this.knownLabels[keyString] = label
             this.logLabel(`🔑 ${label}: ${keyString}`)
+            logTrace(`🔑 ${label}: ${keyString}`)
           }
         }
       }

--- a/amman-client/src/diagnostics/address-labels.ts
+++ b/amman-client/src/diagnostics/address-labels.ts
@@ -8,10 +8,10 @@ import {
   isValidSolanaAddress,
 } from '../utils/address'
 import { KeyLike, isKeyLike, publicKeyString } from '../utils/keys'
-import { logError, scopedLog } from '../utils/log'
+import { scopedLog } from '../utils/log'
 import { mapLabel } from './address-label-mapper'
 
-const { logTrace } = scopedLog('addr')
+const { logError, logTrace } = scopedLog('addr')
 
 /** @private */
 export type AddLabel = (

--- a/amman-client/src/diagnostics/address-labels.ts
+++ b/amman-client/src/diagnostics/address-labels.ts
@@ -276,11 +276,15 @@ export class AddressLabels {
    *
    * @private
    */
-  storeKeypair(keypair: Keypair, label?: string) {
-    return this.ammanClient.requestStoreKeypair(
+  async storeKeypair(keypair: Keypair, label?: string) {
+    if (label != null) {
+      label = await this._nonCollidingLabel(label, keypair.publicKey.toBase58())
+    }
+    await this.ammanClient.requestStoreKeypair(
       label ?? keypair.publicKey.toBase58(),
       keypair
     )
+    return label
   }
 
   /**

--- a/amman-client/src/relay/consts.ts
+++ b/amman-client/src/relay/consts.ts
@@ -43,6 +43,11 @@ export const MSG_REQUEST_LOAD_KEYPAIR = 'request:load-keypair'
 export const MSG_RESPOND_LOAD_KEYPAIR = 'respond:load-keypair'
 
 /** @private */
+export const MSG_REQUEST_SET_ACCOUNT = 'request:set-account'
+/** @private */
+export const MSG_RESPOND_SET_ACCOUNT = 'respond:set-account'
+
+/** @private */
 export const MSG_REQUEST_AMMAN_VERSION = 'request:relay-version'
 /** @private */
 export const MSG_RESPOND_AMMAN_VERSION = 'respond:relay-version'

--- a/amman-client/src/utils/log.ts
+++ b/amman-client/src/utils/log.ts
@@ -14,9 +14,11 @@ export const logInfo = logInfoDebug.enabled
   : console.log.bind(console)
 
 export function scopedLog(scope: string) {
+  const logError = debug(`amman:${scope}:error`)
+  const logInfo = debug(`amman:${scope}:info`)
   return {
-    logError: debug(`amman:${scope}:error`),
-    logInfo: debug(`amman:${scope}:info`),
+    logError: logError.enabled ? logError : console.error.bind(console),
+    logInfo: logInfo.enabled ? logInfo : console.log.bind(console),
     logDebug: debug(`amman:${scope}:debug`),
     logTrace: debug(`amman:${scope}:trace`),
   }

--- a/amman-client/src/utils/log.ts
+++ b/amman-client/src/utils/log.ts
@@ -1,9 +1,9 @@
 import debug from 'debug'
 
-export const logErrorDebug = debug('amman-client:error')
-export const logInfoDebug = debug('amman-client:info')
-export const logDebug = debug('amman-client:debug')
-export const logTrace = debug('amman-client:trace')
+export const logErrorDebug = debug('amman:error')
+export const logInfoDebug = debug('amman:info')
+export const logDebug = debug('amman:debug')
+export const logTrace = debug('amman:trace')
 
 export const logError = logErrorDebug.enabled
   ? logErrorDebug
@@ -13,6 +13,11 @@ export const logInfo = logInfoDebug.enabled
   ? logInfoDebug
   : console.log.bind(console)
 
-export function scopedLog(level: string, scope: string) {
-  return debug(`amman-client:${scope}:${level}`)
+export function scopedLog(scope: string) {
+  return {
+    logError: debug(`amman:${scope}:error`),
+    logInfo: debug(`amman:${scope}:info`),
+    logDebug: debug(`amman:${scope}:debug`),
+    logTrace: debug(`amman:${scope}:trace`),
+  }
 }

--- a/amman/src/assets/persistence.ts
+++ b/amman/src/assets/persistence.ts
@@ -241,7 +241,7 @@ export async function createTemporarySnapshot(
     snapshotFolder,
     new Connection(LOCALHOST, 'confirmed')
   )
-  await persister.snapshot(
+  const snapshotDir = await persister.snapshot(
     label,
     addresses,
     accountLabels,
@@ -249,5 +249,9 @@ export async function createTemporarySnapshot(
     accountOverrides
   )
 
-  return config
+  function cleanupSnapshotDir() {
+    return fs.rm(snapshotDir, { recursive: true })
+  }
+
+  return { config, cleanupSnapshotDir }
 }

--- a/amman/src/assets/persistence.ts
+++ b/amman/src/assets/persistence.ts
@@ -119,6 +119,7 @@ export class AccountPersister {
         // Save override if present
         const override = accountOverrides.get(address)
         if (override != null) {
+          logTrace('Saving override account info %O', address)
           return this.savePersistedAccountInfo(
             override,
             subdir,

--- a/amman/src/cli/commands/start.ts
+++ b/amman/src/cli/commands/start.ts
@@ -14,7 +14,7 @@ export type StartCommandArgs = {
 }
 
 export async function handleStartCommand(args: StartCommandArgs) {
-  let config: AmmanConfig, configPath
+  let config: Required<AmmanConfig>, configPath
   try {
     try {
       ;({ config, configPath } = await resolveConfig(args))
@@ -34,14 +34,8 @@ export async function handleStartCommand(args: StartCommandArgs) {
       `Running validator with ${config.validator.programs.length} custom program(s) and ${config.validator.accounts.length} remote account(s) preloaded`
     )
     logDebug(config.validator)
-    await initValidator(
-      config.validator,
-      config.relay,
-      { ...config.snapshot, load: args.load },
-      config.storage,
-      config.assetsFolder,
-      args.forceClone
-    )
+    config.snapshot = { ...config.snapshot, load: args.load }
+    await initValidator(config, args.forceClone)
 
     if (config.streamTransactionLogs) {
       pipeSolanaLogs(cliAmmanInstance())
@@ -53,7 +47,10 @@ export async function handleStartCommand(args: StartCommandArgs) {
   }
 }
 
-async function resolveConfig({ config }: StartCommandArgs) {
+async function resolveConfig({ config }: StartCommandArgs): Promise<{
+  config: Required<AmmanConfig>
+  configPath: string | null
+}> {
   if (config == null) {
     const { config: localConfig, configPath } = await tryLoadLocalConfigRc()
     return { config: completeConfig(localConfig), configPath }

--- a/amman/src/storage/mock-server.ts
+++ b/amman/src/storage/mock-server.ts
@@ -15,9 +15,7 @@ import { DEFAULT_STORAGE_CONFIG } from './types'
 
 export const AMMAN_STORAGE_ROOT = path.join(tmpdir(), 'amman-storage')
 
-const logError = scopedLog('error', 'mock-storage')
-const logDebug = scopedLog('debug', 'mock-storage')
-const logTrace = scopedLog('trace', 'mock-storage')
+const { logError, logDebug, logTrace } = scopedLog('mock-storage')
 
 export class MockStorageServer {
   server?: Server

--- a/amman/src/types.ts
+++ b/amman/src/types.ts
@@ -22,7 +22,7 @@ export type AmmanConfig = {
   validator?: ValidatorConfig
   relay?: RelayConfig
   storage?: StorageConfig
-  snapshot: SnapshotConfig
+  snapshot?: SnapshotConfig
   streamTransactionLogs?: boolean
   assetsFolder?: string
 }

--- a/amman/src/utils/config.ts
+++ b/amman/src/utils/config.ts
@@ -26,7 +26,9 @@ export const DEFAULT_START_CONFIG: AmmanConfig = {
  *
  * @private
  */
-export function completeConfig(config: Partial<AmmanConfig> = {}): AmmanConfig {
+export function completeConfig(
+  config: Partial<AmmanConfig> = {}
+): Required<AmmanConfig> {
   const validator = { ...DEFAULT_VALIDATOR_CONFIG, ...config.validator }
   const relay = { ...DEFAULT_RELAY_CONFIG, ...config.relay }
   const snapshot = { ...DEFAULT_SNAPSHOT_CONFIG, ...config.snapshot }

--- a/amman/src/utils/log.ts
+++ b/amman/src/utils/log.ts
@@ -14,9 +14,11 @@ export const logInfo = logInfoDebug.enabled
   : console.log.bind(console)
 
 export function scopedLog(scope: string) {
+  const logError = debug(`amman:${scope}:error`)
+  const logInfo = debug(`amman:${scope}:info`)
   return {
-    logError: debug(`amman:${scope}:error`),
-    logInfo: debug(`amman:${scope}:info`),
+    logError: logError.enabled ? logError : console.error.bind(console),
+    logInfo: logInfo.enabled ? logInfo : console.log.bind(console),
     logDebug: debug(`amman:${scope}:debug`),
     logTrace: debug(`amman:${scope}:trace`),
   }

--- a/amman/src/utils/log.ts
+++ b/amman/src/utils/log.ts
@@ -13,6 +13,11 @@ export const logInfo = logInfoDebug.enabled
   ? logInfoDebug
   : console.log.bind(console)
 
-export function scopedLog(level: string, scope: string) {
-  return debug(`amman:${scope}:${level}`)
+export function scopedLog(scope: string) {
+  return {
+    logError: debug(`amman:${scope}:error`),
+    logInfo: debug(`amman:${scope}:info`),
+    logDebug: debug(`amman:${scope}:debug`),
+    logTrace: debug(`amman:${scope}:trace`),
+  }
 }

--- a/amman/src/validator/ensure-validator-up.ts
+++ b/amman/src/validator/ensure-validator-up.ts
@@ -33,6 +33,7 @@ export async function ensureValidatorIsUp(
     validateStatus: (status: number) => status === 405,
     log: false,
   })
+  await ensureWeb3Connection(connectionURL)
   if (verifyFees) {
     logDebug('Ensuring validator charges fees ...')
 
@@ -40,6 +41,16 @@ export async function ensureValidatorIsUp(
     const connection = new Connection(connectionURL, 'confirmed')
     await airdrop(connection, payer.publicKey, 200)
     return ensureFees(connectionURL, payer)
+  }
+}
+
+async function ensureWeb3Connection(connectionURL: string): Promise<void> {
+  const connection = new Connection(connectionURL, 'confirmed')
+  try {
+    await connection.getAccountInfo(SystemProgram.programId)
+  } catch (err) {
+    await sleep(200)
+    return ensureWeb3Connection(connectionURL)
   }
 }
 
@@ -55,12 +66,12 @@ async function ensureFees(
     toPubkey: receiver.publicKey,
   })
   const transaction = new Transaction().add(transferIx)
-  const recentBlockhash = (await connection.getRecentBlockhash('confirmed'))
+  const recentBlockhash = (await connection.getLatestBlockhash('confirmed'))
     .blockhash
   transaction.recentBlockhash = recentBlockhash
   const sig = await connection.sendTransaction(transaction, [payer])
   await connection.confirmTransaction(sig)
-  const confirmedTx = await connection.getConfirmedTransaction(sig)
+  const confirmedTx = await connection.getTransaction(sig)
 
   if (confirmedTx?.meta?.fee === 0) {
     logDebug('Transaction completed without charging fees, trying again ...')

--- a/amman/src/validator/index.ts
+++ b/amman/src/validator/index.ts
@@ -1,1 +1,2 @@
+export * from './solana-validator'
 export * from './init-validator'

--- a/amman/src/validator/init-validator.ts
+++ b/amman/src/validator/init-validator.ts
@@ -2,24 +2,20 @@ import {
   LOCALHOST,
   AMMAN_STORAGE_PORT,
 } from '@metaplex-foundation/amman-client'
-import { execSync as exec, spawn } from 'child_process'
+import { execSync as exec } from 'child_process'
 import http from 'http'
 import { mapPersistedAccountInfos } from '../assets'
-import { DEFAULT_ASSETS_FOLDER, SnapshotConfig } from '../assets/types'
 import { Relay } from '../relay/server'
-import { DEFAULT_RELAY_CONFIG, RelayConfig } from '../relay/types'
-import {
-  DEFAULT_STORAGE_CONFIG,
-  MockStorageServer,
-  StorageConfig,
-} from '../storage'
-import { logError, logInfo, logTrace, sleep, tmpLedgerDir } from '../utils'
-import { canAccessSync } from '../utils/fs'
+import { RelayConfig } from '../relay/types'
+import { MockStorageServer } from '../storage'
+import { AmmanConfig } from '../types'
+import { logError, logInfo, sleep, tmpLedgerDir } from '../utils'
 import { killRunningServer, resolveServerAddress } from '../utils/http'
-import { ensureValidatorIsUp } from './ensure-validator-up'
-import { solanaConfig } from './prepare-config'
-import { processAccounts } from './process-accounts'
-import { processSnapshot } from './process-snapshot'
+import {
+  buildSolanaValidatorArgs,
+  startSolanaValidator,
+  waitForValidator,
+} from './solana-validator'
 import { ValidatorConfig } from './types'
 
 /**
@@ -44,36 +40,24 @@ export const DEFAULT_VALIDATOR_CONFIG: ValidatorConfig = {
  * @private
  */
 export async function initValidator(
-  validatorConfig: Partial<ValidatorConfig>,
-  relayConfig: Partial<RelayConfig> = {},
-  snapshotConfig: SnapshotConfig,
-  storageConfig?: StorageConfig,
-  assetsFolder: string = DEFAULT_ASSETS_FOLDER,
+  config: Required<AmmanConfig>,
   forceClone?: boolean
 ) {
   const {
     killRunningValidators,
     programs,
-    accountsCluster,
     accounts,
     jsonRpcUrl,
-    websocketUrl,
-    commitment,
     ledgerDir,
-    resetLedger,
-    limitLedgerSize,
     verifyFees,
     detached,
-  }: ValidatorConfig = { ...DEFAULT_VALIDATOR_CONFIG, ...validatorConfig }
+  }: ValidatorConfig = config.validator
   const {
     killRunningRelay,
     accountProviders,
     accountRenderers,
     enabled: relayEnabled,
-  }: RelayConfig = {
-    ...DEFAULT_RELAY_CONFIG,
-    ...relayConfig,
-  }
+  }: RelayConfig = config.relay
 
   // -----------------
   // Kill running validators
@@ -87,72 +71,22 @@ export async function initValidator(
   }
 
   // -----------------
-  // Setup Solana Config
-  // -----------------
-  const { configPath, cleanupConfig } = await solanaConfig({
-    websocketUrl,
-    jsonRpcUrl,
-    commitment,
-  })
-
-  let args = ['--quiet', '-C', configPath, '--ledger', ledgerDir]
-  if (resetLedger) args.push('-r')
-  args.push(...['--limit-ledger-size', limitLedgerSize.toString()])
-
-  // -----------------
-  // Deploy Programs
-  // -----------------
-  if (programs.length > 0) {
-    for (const { programId, deployPath } of programs) {
-      if (!canAccessSync(deployPath)) {
-        throw new Error(`Cannot access program deploy path of ${deployPath}`)
-      }
-      args.push('--bpf-program')
-      args.push(programId)
-      args.push(deployPath)
-    }
-  }
-
-  // -----------------
-  // Add Cloned Accounts
-  // -----------------
-  const { accountsArgs, persistedAccountInfos, accountsFolder } =
-    await processAccounts(accounts, accountsCluster, assetsFolder, forceClone)
-  args = [...args, ...accountsArgs]
-
-  // -----------------
-  // Add Snapshot
-  // -----------------
-  const {
-    snapshotArgs,
-    persistedSnapshotAccountInfos,
-    snapshotAccounts,
-    keypairs,
-  } = await processSnapshot(snapshotConfig)
-  args = [...args, ...snapshotArgs]
-
-  // -----------------
   // Launch Validator
   // -----------------
-  const cmd = `solana-test-validator ${args.join(' \\\n  ')}`
-  if (logTrace.enabled) {
-    logTrace('Launching validator with the following command')
-    console.log(cmd)
-  }
-
-  const child = spawn('solana-test-validator', args, {
-    detached,
-    stdio: 'inherit',
-  })
-  child.unref()
-  await new Promise((resolve, reject) => {
-    child.on('spawn', resolve).on('error', reject)
-  })
-
   logInfo(
-    'Spawning new solana-test-validator with programs predeployed and ledger at %s',
+    'Launching new solana-test-validator with programs predeployed and ledger at %s',
     ledgerDir
   )
+  const {
+    args,
+    persistedAccountInfos,
+    persistedSnapshotAccountInfos,
+    snapshotAccounts,
+    accountsFolder,
+    keypairs,
+    cleanupConfig,
+  } = await buildSolanaValidatorArgs(config, forceClone ?? false)
+  const validator = await startSolanaValidator(args, detached, cleanupConfig)
 
   // -----------------
   // Launch relay server in parallel
@@ -170,7 +104,7 @@ export async function initValidator(
       accountInfos,
       keypairs,
       accountsFolder,
-      snapshotConfig.snapshotFolder,
+      config.snapshot.snapshotFolder,
       killRunningRelay
     )
       .then(({ app }) => {
@@ -186,14 +120,10 @@ export async function initValidator(
   // -----------------
   // Launch Storage server in parallel as well
   // -----------------
-  const storageEnabled =
-    storageConfig != null &&
-    { ...DEFAULT_STORAGE_CONFIG, ...storageConfig }.enabled
-
-  if (storageEnabled) {
+  if (config.storage.enabled) {
     killRunningServer(AMMAN_STORAGE_PORT)
       .then(() =>
-        MockStorageServer.createInstance(storageConfig).then((storage) =>
+        MockStorageServer.createInstance(config.storage).then((storage) =>
           storage.start()
         )
       )
@@ -213,8 +143,7 @@ export async function initValidator(
   // -----------------
   // Wait for validator to come up and cleanup
   // -----------------
-  await ensureValidatorIsUp(jsonRpcUrl, verifyFees)
-  await cleanupConfig()
+  await waitForValidator(jsonRpcUrl, verifyFees, cleanupConfig)
 
   logInfo('solana-test-validator is up')
 }

--- a/amman/src/validator/init-validator.ts
+++ b/amman/src/validator/init-validator.ts
@@ -16,7 +16,7 @@ import {
   startSolanaValidator,
   waitForValidator,
 } from './solana-validator'
-import { ValidatorConfig } from './types'
+import { AmmanState, ValidatorConfig } from './types'
 
 /**
  * @private
@@ -86,7 +86,12 @@ export async function initValidator(
     keypairs,
     cleanupConfig,
   } = await buildSolanaValidatorArgs(config, forceClone ?? false)
-  const validator = await startSolanaValidator(args, detached, cleanupConfig)
+  const validator = await startSolanaValidator(args, detached)
+  const ammanState: AmmanState = {
+    validator,
+    detached,
+    config,
+  }
 
   // -----------------
   // Launch relay server in parallel
@@ -97,6 +102,7 @@ export async function initValidator(
       ...persistedSnapshotAccountInfos,
     ])
     Relay.startServer(
+      ammanState,
       accountProviders,
       accountRenderers,
       programs,
@@ -144,6 +150,4 @@ export async function initValidator(
   // Wait for validator to come up and cleanup
   // -----------------
   await waitForValidator(jsonRpcUrl, verifyFees, cleanupConfig)
-
-  logInfo('solana-test-validator is up')
 }

--- a/amman/src/validator/process-snapshot.ts
+++ b/amman/src/validator/process-snapshot.ts
@@ -1,8 +1,8 @@
+import { PersistedAccountInfo } from '@metaplex-foundation/amman-client'
 import { Keypair } from '@solana/web3.js'
 import { promises as fs } from 'fs'
 import path from 'path'
 import {
-  PersistedAccountInfo,
   SnapshotConfig,
   SNAPSHOT_ACCOUNTS_DIR,
   SNAPSHOT_KEYPAIRS_DIR,

--- a/amman/src/validator/solana-validator.ts
+++ b/amman/src/validator/solana-validator.ts
@@ -1,0 +1,111 @@
+import { ChildProcess, spawn } from 'child_process'
+import { AmmanConfig } from '../types'
+import { canAccessSync } from '../utils/fs'
+import { ensureValidatorIsUp } from './ensure-validator-up'
+import { solanaConfig } from './prepare-config'
+import { processAccounts } from './process-accounts'
+import { processSnapshot } from './process-snapshot'
+
+export async function buildSolanaValidatorArgs(
+  config: Required<AmmanConfig>,
+  forceClone: boolean
+) {
+  const validatorConfig = config.validator
+  const {
+    programs,
+    accountsCluster,
+    accounts,
+    ledgerDir,
+    resetLedger,
+    limitLedgerSize,
+    websocketUrl,
+    jsonRpcUrl,
+    commitment,
+  } = validatorConfig
+
+  const { assetsFolder } = config
+
+  // -----------------
+  // Setup Solana Config
+  // -----------------
+  const { configPath, cleanupConfig } = await solanaConfig({
+    websocketUrl,
+    jsonRpcUrl,
+    commitment,
+  })
+
+  let args = ['--quiet', '-C', configPath, '--ledger', ledgerDir]
+  if (resetLedger) args.push('-r')
+  args.push(...['--limit-ledger-size', limitLedgerSize.toString()])
+
+  // -----------------
+  // Deploy Programs
+  // -----------------
+  if (programs.length > 0) {
+    for (const { programId, deployPath } of programs) {
+      if (!canAccessSync(deployPath)) {
+        throw new Error(`Cannot access program deploy path of ${deployPath}`)
+      }
+      args.push('--bpf-program')
+      args.push(programId)
+      args.push(deployPath)
+    }
+  }
+
+  // -----------------
+  // Add Cloned Accounts
+  // -----------------
+  const { accountsArgs, persistedAccountInfos, accountsFolder } =
+    await processAccounts(accounts, accountsCluster, assetsFolder, forceClone)
+  args = [...args, ...accountsArgs]
+
+  // -----------------
+  // Add Snapshot
+  // -----------------
+  const {
+    snapshotArgs,
+    persistedSnapshotAccountInfos,
+    snapshotAccounts,
+    keypairs,
+  } = await processSnapshot(config.snapshot)
+  args = [...args, ...snapshotArgs]
+
+  return {
+    args,
+    persistedAccountInfos,
+    persistedSnapshotAccountInfos,
+    snapshotAccounts,
+    accountsFolder,
+    keypairs,
+    cleanupConfig,
+  }
+}
+
+export async function startSolanaValidator(args: string[], detached: boolean) {
+  const child = spawn('solana-test-validator', args, {
+    detached,
+    stdio: 'inherit',
+  })
+  child.unref()
+  await new Promise((resolve, reject) => {
+    child.on('spawn', resolve).on('error', reject)
+  })
+
+  return child
+}
+
+export async function waitForValidator(
+  jsonRpcUrl: string,
+  verifyFees: boolean,
+  cleanupConfig: () => Promise<void>
+) {
+  await ensureValidatorIsUp(jsonRpcUrl, verifyFees)
+  await cleanupConfig()
+}
+
+export async function killValidatorChild(child: ChildProcess) {
+  child.kill()
+  await new Promise((resolve, reject) => {
+    child.on('exit', resolve).on('error', reject)
+  })
+}

--- a/amman/src/validator/solana-validator.ts
+++ b/amman/src/validator/solana-validator.ts
@@ -130,12 +130,13 @@ export async function restartValidator(
 ) {
   logDebug('Restarting validator')
 
-  const snapshot = await createTemporarySnapshot(
-    addresses,
-    accountLabels,
-    keypairs,
-    accountOverrides
-  )
+  const { config: snapshot, cleanupSnapshotDir } =
+    await createTemporarySnapshot(
+      addresses,
+      accountLabels,
+      keypairs,
+      accountOverrides
+    )
   await killValidatorChild(ammanState.validator)
 
   const config: Required<AmmanConfig> = { ...ammanState.config, snapshot }
@@ -149,4 +150,6 @@ export async function restartValidator(
     config.validator.verifyFees,
     cleanupConfig
   )
+
+  await cleanupSnapshotDir()
 }

--- a/amman/src/validator/solana-validator.ts
+++ b/amman/src/validator/solana-validator.ts
@@ -139,6 +139,7 @@ export async function restartValidator(
   await killValidatorChild(ammanState.validator)
 
   const config: Required<AmmanConfig> = { ...ammanState.config, snapshot }
+  // TODO(thlorenz): Ideally we'd update account states, etc. like we do on main startup
   const { args, cleanupConfig } = await buildSolanaValidatorArgs(config, false)
   const validator = await startSolanaValidator(args, ammanState.detached)
   ammanState.validator = validator

--- a/amman/src/validator/types.ts
+++ b/amman/src/validator/types.ts
@@ -1,4 +1,6 @@
 import { Commitment } from '@solana/web3.js'
+import { ChildProcess } from 'child_process'
+import { AmmanConfig } from '../types'
 
 /**
  * Definition of a bpf program which the test-validator loads at startup.
@@ -75,4 +77,9 @@ export type ValidatorConfig = {
   limitLedgerSize: number
   verifyFees: boolean
   detached: boolean
+}
+
+export type AmmanState = {
+  config: Required<AmmanConfig>
+  validator: ChildProcess
 }

--- a/amman/src/validator/types.ts
+++ b/amman/src/validator/types.ts
@@ -82,4 +82,5 @@ export type ValidatorConfig = {
 export type AmmanState = {
   config: Required<AmmanConfig>
   validator: ChildProcess
+  detached: boolean
 }


### PR DESCRIPTION
## Summary

This PR adds the ability to modify account data + lamports/owner via an interface like the
below:

```ts
const modifier = await amman.accountModifier(gamePda, Game)
await modifier
  .setLamports(1e9)
  .setOwner(otherOwnerPubkey)
  .updateData({ board })
  .commit()
```

It works by taking a snapshot of current accounts + saving the account override for the account
being modified.
This snapshot is saved to a temporary directory.

The validator is the stopped and restarted providing that snapshot.

## Additional Improvments

- scoped logging was added in order to hone in on a subsystem of amman by specifying the
  appropriate `DEBUG` var, i.e. ` DEBUG='amman:(validator|persist):*' amman start`
- keypair ids saved to a snapshot no longer collide

## Remaining Work

At this point the account states and labels aren't updated which can lead to inconsistencies
when using this feature. For instance logging the account state of the modified account still
will show the last known state that was _logged_ by the solana validator.

However this feature is already useful now which is why I'm publishing as is. It is not
documented yet, so only few will discover to use it.
