### PR TITLE
chore: fix relay-timeout and deprecate account modifier

### DIFF
--- a/amman-client/src/api.ts
+++ b/amman-client/src/api.ts
@@ -191,6 +191,19 @@ export class Amman {
   // -----------------
   // Validator Injection
   // -----------------
+  /**
+   * This is an API that allows modifying accounts via validator restart.
+   * However it does not work reliably while running tests and thus should only
+   * be used to experiment.
+   *
+   * It is still useful to modify an account and save it or create a snapshot.
+   * Then you can load that account or snapshot on startup and use it in your tests.
+   *
+   * For use while running tests it is deprecated until we find a better
+   * solution to achieve the same in a more reliable way.
+   *
+   * @deprecated (for now)
+   */
   accountModifier<T>(
     address: PublicKey,
     serializer?: AccountDataSerializer<T>,

--- a/amman-client/src/relay/client.ts
+++ b/amman-client/src/relay/client.ts
@@ -259,7 +259,7 @@ export class ConnectedAmmanClient implements AmmanClient {
         timeoutMs,
         new Error(`Unable to ${action}. ${AMMAN_NOT_RUNNING_ERROR}`),
         (reason: any) => {
-          logTrace(`'${request}' timed out`)
+          logError(`'${request}' timed out`)
           reject(reason)
         }
       )

--- a/amman/src/relay/server.ts
+++ b/amman/src/relay/server.ts
@@ -95,9 +95,7 @@ class RelayServer {
       .on(MSG_REQUEST_ACCOUNT_STATES, (pubkey: string) => {
         logTrace(MSG_REQUEST_ACCOUNT_STATES, pubkey)
         const states = this.accountStates.get(pubkey)?.relayStates
-        if (states != null) {
-          socket.emit(MSG_RESPOND_ACCOUNT_STATES, pubkey, states)
-        }
+        socket.emit(MSG_RESPOND_ACCOUNT_STATES, pubkey, states ?? [])
         if (!subscribedAccountStates.has(pubkey)) {
           subscribedAccountStates.add(pubkey)
           this.accountStates.on(`account-changed:${pubkey}`, (states) => {

--- a/amman/src/validator/solana-validator.ts
+++ b/amman/src/validator/solana-validator.ts
@@ -113,13 +113,23 @@ export async function waitForValidator(
   logInfo('up and running')
 }
 
-export async function killValidatorChild(child: ChildProcess) {
+export function killValidatorChild(child: ChildProcess) {
   child.kill()
-  await new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     child.on('exit', resolve).on('error', reject)
   })
 }
 
+/**
+ * Attempts to kill and restart the validator creating a snapshot of accounts and keypairs first.
+ * That same snapshot is then loaded on restart.
+ *
+ * NOTE: that for now this seems to only work once, i.e. the validator fails to
+ * handle transactions after it is restarted twice (they time out after 30secs)
+ *
+ * @param accountOverrides allow to override some accounts that are written to the snapshot
+ *
+ */
 export async function restartValidator(
   ammanState: AmmanState,
   addresses: string[],


### PR DESCRIPTION
- relay: always respond to account states request even if empty
- chore: mark account modifier as deprecated for now
