### PR TITLE
feat: adding working mock driver compat with latest JS SDK

### DIFF
--- a/amman-client/package.json
+++ b/amman-client/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@metaplex-foundation/cusper": "^0.0.2",
     "@solana/spl-token-registry": "^0.2.2405",
-    "@solana/web3.js": "^1.35.0",
+    "@solana/web3.js": "^1.43.4",
     "debug": "^4.3.3",
     "js-sha3": "^0.8.0",
     "socket.io-client": "^4.4.1",

--- a/amman-client/package.json
+++ b/amman-client/package.json
@@ -46,12 +46,14 @@
     "@metaplex-foundation/cusper": "^0.0.2",
     "@solana/spl-token-registry": "^0.2.2405",
     "@solana/web3.js": "^1.43.4",
+    "bn.js": "^5.2.1",
     "debug": "^4.3.3",
     "js-sha3": "^0.8.0",
     "socket.io-client": "^4.4.1",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
+    "@types/bn.js": "^5.1.0",
     "@types/debug": "^4.1.7",
     "@types/deep-diff": "^1.0.1",
     "@types/diff": "^5.0.2",

--- a/amman-client/src/storage/api.ts
+++ b/amman-client/src/storage/api.ts
@@ -1,1 +1,2 @@
 export * from './consts'
+export * from './mock-storage-driver'

--- a/amman-client/src/storage/consts.ts
+++ b/amman-client/src/storage/consts.ts
@@ -1,3 +1,4 @@
 export const AMMAN_STORAGE_PORT = 50475
 export const AMMAN_STORAGE_URI = `http://localhost:${AMMAN_STORAGE_PORT}`
 export const AMMAN_STORAGE_UPLOAD_URI = `http://localhost:${AMMAN_STORAGE_PORT}/upload`
+export const AMMAN_DEFAULT_MOCK_STORAGE_ID = 'mock'

--- a/amman-client/src/storage/mock-storage-driver.ts
+++ b/amman-client/src/storage/mock-storage-driver.ts
@@ -1,0 +1,84 @@
+import { scopedLog } from '../utils/log'
+import { AMMAN_STORAGE_UPLOAD_URI, AMMAN_STORAGE_URI } from './consts'
+import { Amount, MetaplexFile, sol, StorageDriver } from './sdk-types'
+
+const { logError, logDebug } = scopedLog('mock-storage')
+
+export function ammanMockStorage(storageId: string, costPerByte?: number) {
+  return new AmmanMockStorageDriver(storageId, costPerByte)
+}
+
+class AmmanMockStorageDriver implements StorageDriver {
+  private cache: Record<string, MetaplexFile> = {}
+
+  readonly baseResourceUrl: string
+  readonly baseUploadUrl: string
+
+  constructor(readonly storageId: string, readonly costPerByte: number = 1) {
+    this.baseResourceUrl = AmmanMockStorageDriver.getStorageUri(storageId)
+    this.baseUploadUrl = AmmanMockStorageDriver.getUploadToStorageUri(storageId)
+    logDebug(`Amman Storage Driver for ${this.baseResourceUrl} initialized`)
+  }
+
+  getUploadPrice: (bytes: number) => Promise<Amount> = (bytes) => {
+    const price = bytes * this.costPerByte
+    const amount = sol(price)
+    return Promise.resolve(amount)
+  }
+
+  upload: (file: MetaplexFile) => Promise<string> = async (file) => {
+    const resourceName = file.uniqueName
+    const uploadUri = `${this.baseUploadUrl}/${resourceName}`
+    const resourceUri = `${this.baseResourceUrl}/${resourceName}`
+    const buf = file.buffer
+
+    await uploadBuffer(uploadUri, buf)
+
+    logDebug(`Uploaded ${file.displayName}:${file.uniqueName}`)
+
+    this.cache[resourceUri] = file
+
+    return resourceUri
+  }
+
+  uploadAll: (files: MetaplexFile[]) => Promise<string[]> = async (files) => {
+    return Promise.all(files.map(this.upload))
+  }
+
+  download: (uri: string, options?: RequestInit) => Promise<MetaplexFile> = (
+    uri,
+    _options
+  ) => {
+    const file = this.cache[uri]
+
+    if (file == null) {
+      throw new Error(`Asset for ${uri} not found`)
+    }
+
+    return Promise.resolve(file)
+  }
+
+  static readonly getStorageUri = (storageId: string) =>
+    `${AMMAN_STORAGE_URI}/${storageId}`
+
+  static readonly getUploadToStorageUri = (storageId: string) =>
+    `${AMMAN_STORAGE_UPLOAD_URI}/${storageId}`
+}
+
+// -----------------
+// Helpers
+// -----------------
+export async function uploadBuffer(url: string, buf: Buffer) {
+  const byteSize = buf.byteLength
+  try {
+    return await fetch(url, {
+      method: 'POST',
+      headers: {
+        contentLength: `${byteSize}`,
+      },
+      body: buf,
+    })
+  } catch (err) {
+    logError(`Error uploading ${url}: ${err}`)
+  }
+}

--- a/amman-client/src/storage/mock-storage-driver.ts
+++ b/amman-client/src/storage/mock-storage-driver.ts
@@ -4,11 +4,30 @@ import {
   AMMAN_STORAGE_UPLOAD_URI,
   AMMAN_STORAGE_URI,
 } from './consts'
-import { Amount, MetaplexFile, sol, StorageDriver } from './sdk-types'
+import {
+  Amount,
+  MetaplexFile,
+  MetaplexPlugin,
+  sol,
+  StorageDriver,
+} from './sdk-types'
 
 const { logError, logDebug } = scopedLog('mock-storage')
 
-export function ammanMockStorage(storageId?: string, costPerByte?: number) {
+export const ammanMockStorage = (
+  storageId?: string,
+  costPerByte?: number
+): MetaplexPlugin => ({
+  install(metaplex: any /* Metaplex */) {
+    const driver = ammanMockStorageDriver(storageId, costPerByte)
+    metaplex.storage().setDriver(driver)
+  },
+})
+
+export function ammanMockStorageDriver(
+  storageId?: string,
+  costPerByte?: number
+) {
   return new AmmanMockStorageDriver(storageId, costPerByte)
 }
 

--- a/amman-client/src/storage/mock-storage-driver.ts
+++ b/amman-client/src/storage/mock-storage-driver.ts
@@ -1,10 +1,14 @@
 import { scopedLog } from '../utils/log'
-import { AMMAN_STORAGE_UPLOAD_URI, AMMAN_STORAGE_URI } from './consts'
+import {
+  AMMAN_DEFAULT_MOCK_STORAGE_ID,
+  AMMAN_STORAGE_UPLOAD_URI,
+  AMMAN_STORAGE_URI,
+} from './consts'
 import { Amount, MetaplexFile, sol, StorageDriver } from './sdk-types'
 
 const { logError, logDebug } = scopedLog('mock-storage')
 
-export function ammanMockStorage(storageId: string, costPerByte?: number) {
+export function ammanMockStorage(storageId?: string, costPerByte?: number) {
   return new AmmanMockStorageDriver(storageId, costPerByte)
 }
 
@@ -14,7 +18,10 @@ class AmmanMockStorageDriver implements StorageDriver {
   readonly baseResourceUrl: string
   readonly baseUploadUrl: string
 
-  constructor(readonly storageId: string, readonly costPerByte: number = 1) {
+  constructor(
+    readonly storageId: string = AMMAN_DEFAULT_MOCK_STORAGE_ID,
+    readonly costPerByte: number = 1
+  ) {
     this.baseResourceUrl = AmmanMockStorageDriver.getStorageUri(storageId)
     this.baseUploadUrl = AmmanMockStorageDriver.getUploadToStorageUri(storageId)
     logDebug(`Amman Storage Driver for ${this.baseResourceUrl} initialized`)

--- a/amman-client/src/storage/sdk-types.ts
+++ b/amman-client/src/storage/sdk-types.ts
@@ -2,6 +2,16 @@ import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 import BN from 'bn.js'
 
 // TODO(thlorenz): Copied from SDK for now until a version with those types is published
+// -----------------
+// Metaplex Plugin
+// -----------------
+export type MetaplexPlugin = {
+  install(metaplex: any /* Metaplex */): any
+}
+
+// -----------------
+// Storage Driver
+// -----------------
 export type StorageDriver = {
   getUploadPrice: (bytes: number) => Promise<Amount>
   upload: (file: MetaplexFile) => Promise<string>

--- a/amman-client/src/storage/sdk-types.ts
+++ b/amman-client/src/storage/sdk-types.ts
@@ -1,0 +1,73 @@
+import { LAMPORTS_PER_SOL } from '@solana/web3.js'
+import BN from 'bn.js'
+
+// TODO(thlorenz): Copied from SDK for now until a version with those types is published
+export type StorageDriver = {
+  getUploadPrice: (bytes: number) => Promise<Amount>
+  upload: (file: MetaplexFile) => Promise<string>
+  uploadAll?: (files: MetaplexFile[]) => Promise<string[]>
+  download?: (uri: string, options?: RequestInit) => Promise<MetaplexFile>
+}
+
+// -----------------
+// MetaplexFile
+// -----------------
+export type MetaplexFile = Readonly<{
+  buffer: Buffer
+  fileName: string
+  displayName: string
+  uniqueName: string
+  contentType: string | null
+  extension: string | null
+  tags: MetaplexFileTag[]
+}>
+
+export type MetaplexFileTag = { name: string; value: string }
+
+// -----------------
+// Amount
+// -----------------
+export type Amount = {
+  basisPoints: BasisPoints
+  currency: Currency
+}
+
+export type BasisPoints = Opaque<BN, 'BasisPoints'>
+
+export type Currency = {
+  symbol: string
+  decimals: number
+  namespace?: 'spl-token'
+}
+
+export type Opaque<T, K> = T & { __opaque__: K }
+
+export const SOL = {
+  symbol: 'SOL',
+  decimals: 9,
+}
+
+// -----------------
+// Amount Helpers
+// -----------------
+export const amount = (
+  basisPoints: number | BN,
+  currency: Currency
+): Amount => {
+  return {
+    basisPoints: toBasisPoints(basisPoints),
+    currency,
+  }
+}
+
+export const lamports = (lamports: number | BN): Amount => {
+  return amount(lamports, SOL)
+}
+
+export const sol = (sol: number): Amount => {
+  return lamports(sol * LAMPORTS_PER_SOL)
+}
+
+export const toBasisPoints = (value: number | BN): BasisPoints => {
+  return new BN(value) as BasisPoints
+}

--- a/amman/package.json
+++ b/amman/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@metaplex-foundation/amman-client": "^0.0.0",
     "@solana/spl-token": "^0.2.0",
-    "@solana/web3.js": "^1.35.0",
+    "@solana/web3.js": "^1.43.4",
     "ansi-colors": "^4.1.1",
     "bn.js": "^5.2.0",
     "buffer-hexdump": "^1.0.0",

--- a/amman/src/storage/mock-server.ts
+++ b/amman/src/storage/mock-server.ts
@@ -77,7 +77,12 @@ export class MockStorageServer {
         } else {
           logDebug(`serving ${resource}`)
           writeStatusHead(res, 200)
-          fs.createReadStream(resource).pipe(res)
+          fs.createReadStream(resource)
+            .on('error', (err) => {
+              logError(err)
+              fail(res, 'Failed to read resource')
+            })
+            .pipe(res)
         }
       })
       .unref()

--- a/amman/src/storage/types.ts
+++ b/amman/src/storage/types.ts
@@ -1,3 +1,5 @@
+import { AMMAN_DEFAULT_MOCK_STORAGE_ID } from '@metaplex-foundation/amman-client'
+
 export const ContentTypes = [
   'image/jpeg',
   'image/png',
@@ -28,6 +30,6 @@ export type StorageConfig = {
  */
 export const DEFAULT_STORAGE_CONFIG: StorageConfig = {
   enabled: process.env.CI == null,
-  storageId: 'storageId',
+  storageId: AMMAN_DEFAULT_MOCK_STORAGE_ID,
   clearOnStart: true,
 }


### PR DESCRIPTION
- chore: upgrade web3.js explictly to latest minor
- sdk: adding sdk types for now
- driver: implementing metaplex file based driver
- storage: defaulting common storage id if not provided
- sdk: provide metaplex compatible mock storage plugin
- mock-server: hardening server to not crash when reading resource fails
