### PR TITLE
chore: amman-client browser compat + improve mock storage

### DIFF
--- a/amman-client/src/relay/client.ts
+++ b/amman-client/src/relay/client.ts
@@ -2,6 +2,7 @@ import { Keypair } from '@solana/web3.js'
 import { strict as assert } from 'assert'
 import io, { Socket } from 'socket.io-client'
 import { PersistedAccountInfo } from '../assets/persistence'
+import { isBrowser } from '../utils/browser'
 import { scopedLog } from '../utils/log'
 import {
   ACK_UPDATE_ADDRESS_LABELS,
@@ -64,7 +65,7 @@ export class ConnectedAmmanClient implements AmmanClient {
   private readonly ack: boolean
   private _reqId = 0
   private constructor(readonly url: string, opts: AmmanClientOpts = {}) {
-    const { autoUnref = true, ack = false } = opts
+    const { autoUnref = !isBrowser, ack = false } = opts
     this.ack = ack
     this.socket = io(url, { autoUnref })
   }

--- a/amman-client/src/storage/mock-storage-driver.ts
+++ b/amman-client/src/storage/mock-storage-driver.ts
@@ -97,14 +97,17 @@ class AmmanMockStorageDriver implements StorageDriver {
 export async function uploadBuffer(url: string, buf: Buffer) {
   const byteSize = buf.byteLength
   try {
-    return await fetch(url, {
+    const res = await fetch(url, {
       method: 'POST',
       headers: {
         contentLength: `${byteSize}`,
       },
       body: buf,
     })
+    await res.text()
+    return res
   } catch (err) {
-    logError(`Error uploading ${url}: ${err}`)
+    logError(`Error uploading ${url}`)
+    logError(err)
   }
 }

--- a/amman-client/src/utils/browser.ts
+++ b/amman-client/src/utils/browser.ts
@@ -1,0 +1,2 @@
+export const isBrowser =
+  typeof window !== 'undefined' && typeof window.document !== 'undefined'


### PR DESCRIPTION
- relay-client: only auto unref when not running in browser
- upload: completing fetch
