### PR TITLE
feat: restart validator + test project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 .idea/
 yarn.lock
+**/yarn.lock

--- a/amman-client/src/api.ts
+++ b/amman-client/src/api.ts
@@ -64,7 +64,7 @@ export class Amman {
     readonly addr: AddressLabels,
     readonly ammanClient: AmmanClient,
     readonly errorResolver?: ErrorResolver
-  ) {}
+  ) { }
   private static _instance: Amman | undefined
 
   // -----------------
@@ -239,6 +239,10 @@ export class Amman {
     )
   }
 
+  restartValidator() {
+    return this.ammanClient.requestRestartValidator()
+  }
+
   loadSnapshot(label: string) {
     return this.ammanClient.requestLoadSnapshot(label)
   }
@@ -335,7 +339,7 @@ export class Amman {
     const { connectClient = process.env.CI == null, ammanClientOpts } = args
     const {
       knownLabels = {},
-      log = (_) => {},
+      log = (_) => { },
       ammanClient = connectClient
         ? ConnectedAmmanClient.getInstance(AMMAN_RELAY_URI, ammanClientOpts)
         : new DisconnectedAmmanClient(),

--- a/amman-client/src/api.ts
+++ b/amman-client/src/api.ts
@@ -64,7 +64,7 @@ export class Amman {
     readonly addr: AddressLabels,
     readonly ammanClient: AmmanClient,
     readonly errorResolver?: ErrorResolver
-  ) { }
+  ) {}
   private static _instance: Amman | undefined
 
   // -----------------
@@ -339,7 +339,7 @@ export class Amman {
     const { connectClient = process.env.CI == null, ammanClientOpts } = args
     const {
       knownLabels = {},
-      log = (_) => { },
+      log = (_) => {},
       ammanClient = connectClient
         ? ConnectedAmmanClient.getInstance(AMMAN_RELAY_URI, ammanClientOpts)
         : new DisconnectedAmmanClient(),

--- a/amman-client/src/relay/client.ts
+++ b/amman-client/src/relay/client.ts
@@ -19,6 +19,7 @@ import {
   MSG_REQUEST_SET_ACCOUNT,
   MSG_REQUEST_SNAPSHOT_SAVE,
   MSG_REQUEST_STORE_KEYPAIR,
+  MSG_REQUEST_VALIDATOR_PID,
   MSG_RESPOND_ACCOUNT_SAVE,
   MSG_RESPOND_ACCOUNT_STATES,
   MSG_RESPOND_AMMAN_VERSION,
@@ -28,6 +29,7 @@ import {
   MSG_RESPOND_SET_ACCOUNT,
   MSG_RESPOND_SNAPSHOT_SAVE,
   MSG_RESPOND_STORE_KEYPAIR,
+  MSG_RESPOND_VALIDATOR_PID,
   MSG_UPDATE_ADDRESS_LABELS,
 } from './consts'
 import { createTimeout } from './timeout'
@@ -162,6 +164,18 @@ export class ConnectedAmmanClient implements AmmanClient {
       MSG_RESPOND_AMMAN_VERSION,
       (resolve, _reject, version) => {
         resolve(version)
+      }
+    )
+  }
+
+  async fetchValidatorPid(): Promise<number> {
+    return this._handleRequest(
+      'fetch validator pid',
+      MSG_REQUEST_VALIDATOR_PID,
+      [],
+      MSG_RESPOND_VALIDATOR_PID,
+      (resolve, _reject, pid) => {
+        resolve(pid)
       }
     )
   }

--- a/amman-client/src/relay/client.ts
+++ b/amman-client/src/relay/client.ts
@@ -12,6 +12,7 @@ import {
   MSG_GET_KNOWN_ADDRESS_LABELS,
   MSG_REQUEST_ACCOUNT_SAVE,
   MSG_REQUEST_ACCOUNT_STATES,
+  MSG_REQUEST_AMMAN_VERSION,
   MSG_REQUEST_LOAD_KEYPAIR,
   MSG_REQUEST_LOAD_SNAPSHOT,
   MSG_REQUEST_RESTART_VALIDATOR,
@@ -20,6 +21,7 @@ import {
   MSG_REQUEST_STORE_KEYPAIR,
   MSG_RESPOND_ACCOUNT_SAVE,
   MSG_RESPOND_ACCOUNT_STATES,
+  MSG_RESPOND_AMMAN_VERSION,
   MSG_RESPOND_LOAD_KEYPAIR,
   MSG_RESPOND_LOAD_SNAPSHOT,
   MSG_RESPOND_RESTART_VALIDATOR,
@@ -96,22 +98,22 @@ export class ConnectedAmmanClient implements AmmanClient {
     }
     const promise = this.ack
       ? new Promise<void>((resolve, reject) => {
-        const timeout = createTimeout(
-          2000,
-          new Error('Unable to add address labels' + AMMAN_NOT_RUNNING_ERROR),
-          reject
-        )
-        this.socket
-          .on('error', (err) => {
-            clearTimeout(timeout)
-            reject(err)
-          })
-          .on(ACK_UPDATE_ADDRESS_LABELS, () => {
-            logTrace('Got ack for address labels update %O', labels)
-            clearTimeout(timeout)
-            resolve()
-          })
-      })
+          const timeout = createTimeout(
+            2000,
+            new Error('Unable to add address labels' + AMMAN_NOT_RUNNING_ERROR),
+            reject
+          )
+          this.socket
+            .on('error', (err) => {
+              clearTimeout(timeout)
+              reject(err)
+            })
+            .on(ACK_UPDATE_ADDRESS_LABELS, () => {
+              logTrace('Got ack for address labels update %O', labels)
+              clearTimeout(timeout)
+              resolve()
+            })
+        })
       : Promise.resolve()
 
     this.socket.emit(MSG_UPDATE_ADDRESS_LABELS, labels)
@@ -149,6 +151,17 @@ export class ConnectedAmmanClient implements AmmanClient {
           states
         )
         resolve(states)
+      }
+    )
+  }
+  async fetchAmmanVersion(): Promise<[number, number, number]> {
+    return this._handleRequest(
+      'fetch versoin',
+      MSG_REQUEST_AMMAN_VERSION,
+      [],
+      MSG_RESPOND_AMMAN_VERSION,
+      (resolve, _reject, version) => {
+        resolve(version)
       }
     )
   }
@@ -343,8 +356,8 @@ export class ConnectedAmmanClient implements AmmanClient {
 
 /** @private */
 export class DisconnectedAmmanClient implements AmmanClient {
-  clearAddressLabels(): void { }
-  clearTransactions(): void { }
+  clearAddressLabels(): void {}
+  clearTransactions(): void {}
   addAddressLabels(_labels: Record<string, string>): Promise<void> {
     return Promise.resolve()
   }
@@ -376,6 +389,6 @@ export class DisconnectedAmmanClient implements AmmanClient {
   requestRestartValidator(): Promise<void> {
     return Promise.resolve()
   }
-  disconnect() { }
-  destroy() { }
+  disconnect() {}
+  destroy() {}
 }

--- a/amman-client/src/relay/client.ts
+++ b/amman-client/src/relay/client.ts
@@ -156,7 +156,7 @@ export class ConnectedAmmanClient implements AmmanClient {
   }
   async fetchAmmanVersion(): Promise<[number, number, number]> {
     return this._handleRequest(
-      'fetch versoin',
+      'fetch version',
       MSG_REQUEST_AMMAN_VERSION,
       [],
       MSG_RESPOND_AMMAN_VERSION,

--- a/amman-client/src/relay/consts.ts
+++ b/amman-client/src/relay/consts.ts
@@ -61,3 +61,8 @@ export const MSG_RESPOND_RESTART_VALIDATOR = 'respond:restart-validator'
 export const MSG_REQUEST_AMMAN_VERSION = 'request:relay-version'
 /** @private */
 export const MSG_RESPOND_AMMAN_VERSION = 'respond:relay-version'
+
+/** @private */
+export const MSG_REQUEST_VALIDATOR_PID = 'request:validator-pid'
+/** @private */
+export const MSG_RESPOND_VALIDATOR_PID = 'respond:validator-pid'

--- a/amman-client/src/relay/consts.ts
+++ b/amman-client/src/relay/consts.ts
@@ -53,6 +53,11 @@ export const MSG_REQUEST_LOAD_SNAPSHOT = 'request:load-snapshot'
 export const MSG_RESPOND_LOAD_SNAPSHOT = 'respond:load-snapshot'
 
 /** @private */
+export const MSG_REQUEST_RESTART_VALIDATOR = 'request:restart-validator'
+/** @private */
+export const MSG_RESPOND_RESTART_VALIDATOR = 'respond:restart-validator'
+
+/** @private */
 export const MSG_REQUEST_AMMAN_VERSION = 'request:relay-version'
 /** @private */
 export const MSG_RESPOND_AMMAN_VERSION = 'respond:relay-version'

--- a/amman-tests/README.md
+++ b/amman-tests/README.md
@@ -1,0 +1,21 @@
+## amman tests
+
+This package contains integration tests for amman. Most leverage _amman-client_ to communicate
+with amman once it is started up. Thus they are fully end-to-end.
+
+## Running
+
+Run tests simply via `yarn test` executed from the root folder of this test package.
+
+It leverages `esbuild-runner` to run the TypeScript code directly (building on the fly) which
+makes it easier to run them repeatedly as well as reach into nested modules of the packages it
+is testing.
+
+Additionally this allows quick navigation into the code of the respective package, i.e. instead
+of showing the definition file we can jump directly to the project code.
+
+## Caveats
+
+Most tests depend on the fact that they are executed sequentially and in order, for
+instance `./tasks/restart-validator.ts` first fetches the `pid` of the validator in one tests,
+restarts it in the next test and fetches the updated `pid` in the test after.

--- a/amman-tests/package.json
+++ b/amman-tests/package.json
@@ -15,6 +15,10 @@
     "access": "private",
     "registry": "https://registry.npmjs.org"
   },
+  "dependencies": {
+    "@metaplex-foundation/amman": "*",
+    "@metaplex-foundation/amman-client": "*"
+  },
   "devDependencies": {
     "@types/tape": "^4.13.2",
     "esbuild": "^0.14.49",

--- a/amman-tests/package.json
+++ b/amman-tests/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Tests for amman.",
   "scripts": {
-    "test": "for t in ./tests/*.ts; do esr $t; done | tap-spec",
+    "test": "for t in ./tests{,/tasks}/*.ts; do esr $t; done | tap-spec",
     "lint": "prettier -c ./tests/",
     "lint:fix": "prettier --write ./tests"
   },

--- a/amman-tests/package.json
+++ b/amman-tests/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@metaplex-foundation/amman-tests",
+  "version": "0.0.0",
+  "description": "Tests for amman.",
+  "scripts": {
+    "test": "for t in ./tests/*.ts; do esr $t; done | tap-spec",
+    "lint": "prettier -c ./tests/",
+    "lint:fix": "prettier --write ./tests"
+  },
+  "repository": "git@github.com:metaplex-foundation/amman.git",
+  "author": "Thorsten Lorenz <thlorenz@gmx.de>",
+  "license": "Apache-2.0",
+  "private": true,
+  "publishConfig": {
+    "access": "private",
+    "registry": "https://registry.npmjs.org"
+  },
+  "devDependencies": {
+    "@types/tape": "^4.13.2",
+    "esbuild": "^0.14.49",
+    "esbuild-runner": "^2.2.1",
+    "prettier": "^2.7.1",
+    "spok": "^1.4.3",
+    "tap-spec": "^5.0.0",
+    "tape": "^5.5.3"
+  }
+}

--- a/amman-tests/tests/amman-client.ts
+++ b/amman-tests/tests/amman-client.ts
@@ -5,7 +5,7 @@ import { killAmman, launchAmman, relayClient } from './utils/launch'
 
 const DEBUG = true
 
-test('socket-client: amman version', async (t) => {
+test('amman-client: amman version', async (t) => {
   const client = relayClient()
 
   const state = await launchAmman({ streamTransactionLogs: DEBUG })

--- a/amman-tests/tests/amman-client.ts
+++ b/amman-tests/tests/amman-client.ts
@@ -5,14 +5,22 @@ import { killAmman, launchAmman, relayClient } from './utils/launch'
 
 const DEBUG = true
 
-test('amman-client: amman version', async (t) => {
+test('amman-client: given amman is running with the relay enabled', async (t) => {
   const client = relayClient()
-
   const state = await launchAmman({ streamTransactionLogs: DEBUG })
-  {
+
+  t.test('fetch: amman version', async (t) => {
     const version = await client.fetchAmmanVersion()
     spok(t, version, { $topic: 'amman version', ...AMMAN_VERSION })
-  }
-  await killAmman(t, state)
-  t.end()
+  })
+
+  t.test('fetch: validator pid', async (t) => {
+    const pid = await client.fetchValidatorPid()
+    spok(t, { pid }, { $topic: 'validator pid', pid: spok.gtz })
+  })
+
+  t.test('kill amman', async (t) => {
+    await killAmman(t, state)
+    t.pass('properly killed amman')
+  })
 })

--- a/amman-tests/tests/socket-communication.ts
+++ b/amman-tests/tests/socket-communication.ts
@@ -1,6 +1,18 @@
+import { AMMAN_VERSION } from '@metaplex-foundation/amman/src/relay/types'
+import spok from 'spok'
 import test from 'tape'
+import { killAmman, launchAmman, relayClient } from './utils/launch'
 
-test('socket-communication: amman version', (t) => {
-  t.pass('test coming up')
+const DEBUG = true
+
+test('socket-client: amman version', async (t) => {
+  const client = relayClient()
+
+  const state = await launchAmman({ streamTransactionLogs: DEBUG })
+  {
+    const version = await client.fetchAmmanVersion()
+    spok(t, version, { $topic: 'amman version', ...AMMAN_VERSION })
+  }
+  await killAmman(t, state)
   t.end()
 })

--- a/amman-tests/tests/socket-communication.ts
+++ b/amman-tests/tests/socket-communication.ts
@@ -1,0 +1,6 @@
+import test from 'tape'
+
+test('socket-communication: amman version', (t) => {
+  t.pass('test coming up')
+  t.end()
+})

--- a/amman-tests/tests/tasks/restart-validator.ts
+++ b/amman-tests/tests/tasks/restart-validator.ts
@@ -1,0 +1,40 @@
+import spok from 'spok'
+import test from 'tape'
+import { killAmman, launchAmman, relayClient } from '../utils/launch'
+
+test('amman-client: given amman is running with the relay enabled', async (t) => {
+  const client = relayClient()
+  const state = await launchAmman()
+
+  let pidBeforeRestart: number
+
+  t.test('fetch: validator pid', async (t) => {
+    const pid = await client.fetchValidatorPid()
+    spok(t, { pid }, { $topic: 'validator pid', pid: spok.gtz })
+    pidBeforeRestart = pid
+  })
+
+  t.test('request to restart validator', async (t) => {
+    try {
+      await client.requestRestartValidator()
+    } catch (err: any) {
+      t.fail(err)
+    }
+  })
+
+  t.test('fetch: validator pid after restart', async (t) => {
+    const pid = await client.fetchValidatorPid()
+    spok(t, { pid }, { $topic: 'validator pid', pid: spok.gtz })
+    t.notEqual(
+      pid,
+      pidBeforeRestart,
+      'a new validator with different pid has started up'
+    )
+    pidBeforeRestart = pid
+  })
+
+  t.test('kill amman', async (t) => {
+    await killAmman(t, state)
+    t.pass('properly killed amman')
+  })
+})

--- a/amman-tests/tests/utils/launch.ts
+++ b/amman-tests/tests/utils/launch.ts
@@ -1,0 +1,58 @@
+import test, { Test } from 'tape'
+
+import { AmmanConfig } from '@metaplex-foundation/amman'
+import { AMMAN_RELAY_URI } from '@metaplex-foundation/amman-client'
+import { ConnectedAmmanClient } from '@metaplex-foundation/amman-client/src/amman-client'
+import {
+  completeConfig,
+  DEFAULT_START_CONFIG,
+} from '@metaplex-foundation/amman/src/utils/config'
+import { initValidator } from '@metaplex-foundation/amman/src/validator/init-validator'
+import { AmmanStateInternal } from '@metaplex-foundation/amman/src/validator/types'
+
+const DEFAULT_TEST_CONFIG: Required<AmmanConfig> = { ...DEFAULT_START_CONFIG }
+
+DEFAULT_TEST_CONFIG.storage.enabled = false
+DEFAULT_TEST_CONFIG.streamTransactionLogs = false
+
+export async function launchAmman(conf: Partial<AmmanConfig> = {}) {
+  const config = completeConfig({ ...DEFAULT_TEST_CONFIG, ...conf })
+  return initValidator(config) as Promise<AmmanStateInternal>
+}
+
+export async function killAmman(t: Test, ammanState: AmmanStateInternal) {
+  if (ammanState.relayServer != null) {
+    try {
+      await ammanState.relayServer.close()
+    } catch (err) {
+      t.error(err, 'amman relay failed to close properly')
+    }
+  }
+  process.kill(ammanState.pid)
+
+  killStuckProcess()
+}
+
+/**
+ * This is a workaround the fact that web3.js doesn't close it's socket connection and provides no way to do so.
+ * Therefore the process hangs for a considerable time after the tests finish, increasing the feedback loop.
+ *
+ * Therefore until https://github.com/solana-labs/solana/issues/25069 is addressed we'll see:
+ * ws error: connect ECONNREFUSED 127.0.0.1:8900
+ * printed to the console
+ *
+ * This fixes this by exiting the process as soon as all tests are finished.
+ */
+export function killStuckProcess() {
+  // Don't do this in CI since we need to ensure we get a non-zero exit code if tests fail
+  if (process.env.CI == null) {
+    test.onFinish(() => process.exit(0))
+  }
+}
+
+export function relayClient() {
+  return ConnectedAmmanClient.getInstance(AMMAN_RELAY_URI, {
+    autoUnref: true,
+    ack: false,
+  })
+}

--- a/amman-tests/tests/utils/launch.ts
+++ b/amman-tests/tests/utils/launch.ts
@@ -28,7 +28,7 @@ export async function killAmman(t: Test, ammanState: AmmanStateInternal) {
       t.error(err, 'amman relay failed to close properly')
     }
   }
-  process.kill(ammanState.pid)
+  process.kill(ammanState.validator.pid!)
 
   killStuckProcess()
 }

--- a/amman/src/accounts/state.ts
+++ b/amman/src/accounts/state.ts
@@ -82,6 +82,16 @@ export class AccountStates extends EventEmitter {
   // address:{ keypair, id (label) }
   readonly keypairs: Map<string, { keypair: Keypair; id: string }> = new Map()
 
+  private _paused = true
+
+  get paused() {
+    return this._paused
+  }
+
+  set paused(val: boolean) {
+    this._paused = val
+  }
+
   private constructor(
     readonly connection: Connection,
     readonly accountProvider: AccountProvider,
@@ -177,6 +187,8 @@ export class AccountStates extends EventEmitter {
   }
 
   private _onLog = async (logs: Logs, ctx: Context) => {
+    if (this._paused) return
+
     const tx = await this.connection.getTransaction(logs.signature, {
       commitment: 'confirmed',
     })
@@ -189,6 +201,7 @@ export class AccountStates extends EventEmitter {
       .map((x) => x.toBase58())
 
     for (const key of nonProgramAddresses) {
+      if (this._paused) return
       this.update(key, ctx.slot)
     }
   }

--- a/amman/src/relay/server.ts
+++ b/amman/src/relay/server.ts
@@ -177,7 +177,11 @@ class RelayServer {
             persistedAccountInfos,
             persistedSnapshotAccountInfos,
             keypairs,
-          } = await restartValidator(this.ammanState, this.ammanState.config)
+          } = await restartValidator(
+            this.accountStates,
+            this.ammanState,
+            this.ammanState.config
+          )
 
           const accountInfos = mapPersistedAccountInfos([
             ...persistedAccountInfos,

--- a/amman/src/relay/server.ts
+++ b/amman/src/relay/server.ts
@@ -24,6 +24,8 @@ import {
   PersistedAccountInfo,
   MSG_REQUEST_LOAD_SNAPSHOT,
   MSG_RESPOND_LOAD_SNAPSHOT,
+  MSG_REQUEST_VALIDATOR_PID,
+  MSG_RESPOND_VALIDATOR_PID,
 } from '@metaplex-foundation/amman-client'
 import { AccountInfo, Keypair, PublicKey } from '@solana/web3.js'
 import { createServer, Server as HttpServer } from 'http'
@@ -255,6 +257,10 @@ class RelayServer {
       .on(MSG_REQUEST_AMMAN_VERSION, () => {
         logTrace(MSG_REQUEST_AMMAN_VERSION)
         socket.emit(MSG_RESPOND_AMMAN_VERSION, AMMAN_VERSION)
+      })
+      .on(MSG_REQUEST_VALIDATOR_PID, () => {
+        logTrace(MSG_REQUEST_VALIDATOR_PID)
+        socket.emit(MSG_RESPOND_VALIDATOR_PID, this.ammanState.validator.pid ?? 0)
       })
   }
 }

--- a/amman/src/relay/server.ts
+++ b/amman/src/relay/server.ts
@@ -153,7 +153,11 @@ export class RelayServer {
             persistedAccountInfos,
             persistedSnapshotAccountInfos,
             keypairs,
-          } = await restartValidatorWithSnapshot(this.ammanState, label)
+          } = await restartValidatorWithSnapshot(
+            this.accountStates,
+            this.ammanState,
+            label
+          )
 
           const accountInfos = mapPersistedAccountInfos([
             ...persistedAccountInfos,
@@ -223,6 +227,7 @@ export class RelayServer {
         logTrace(MSG_REQUEST_SET_ACCOUNT)
         const addresses = this.accountStates.allAccountAddresses()
         await restartValidatorWithAccountOverrides(
+          this.accountStates,
           this.ammanState,
           addresses,
           this.allKnownLabels,
@@ -234,6 +239,7 @@ export class RelayServer {
           persistedSnapshotAccountInfos,
           keypairs,
         } = await restartValidatorWithAccountOverrides(
+          this.accountStates,
           this.ammanState,
           addresses,
           this.allKnownLabels,
@@ -260,11 +266,16 @@ export class RelayServer {
       })
       .on(MSG_REQUEST_VALIDATOR_PID, () => {
         logTrace(MSG_REQUEST_VALIDATOR_PID)
-        socket.emit(MSG_RESPOND_VALIDATOR_PID, this.ammanState.validator.pid ?? 0)
+        socket.emit(
+          MSG_RESPOND_VALIDATOR_PID,
+          this.ammanState.validator.pid ?? 0
+        )
       })
   }
   close() {
-    return new Promise<void>((resolve, reject) => this.io.close((err) => err ? reject(err) : resolve()))
+    return new Promise<void>((resolve, reject) =>
+      this.io.close((err) => (err ? reject(err) : resolve()))
+    )
   }
 }
 

--- a/amman/src/relay/server.ts
+++ b/amman/src/relay/server.ts
@@ -53,7 +53,7 @@ const { logError, logDebug, logTrace } = scopedLog('relay')
  *
  * @private
  */
-class RelayServer {
+export class RelayServer {
   constructor(
     readonly io: Server,
     readonly ammanState: AmmanState,
@@ -262,6 +262,9 @@ class RelayServer {
         logTrace(MSG_REQUEST_VALIDATOR_PID)
         socket.emit(MSG_RESPOND_VALIDATOR_PID, this.ammanState.validator.pid ?? 0)
       })
+  }
+  close() {
+    return new Promise<void>((resolve, reject) => this.io.close((err) => err ? reject(err) : resolve()))
   }
 }
 

--- a/amman/src/utils/config.ts
+++ b/amman/src/utils/config.ts
@@ -11,7 +11,7 @@ import { DEFAULT_VALIDATOR_CONFIG } from '../validator'
 
 export const DEFAULT_STREAM_TRANSACTION_LOGS = process.env.CI == null
 
-export const DEFAULT_START_CONFIG: AmmanConfig = {
+export const DEFAULT_START_CONFIG: Required<AmmanConfig> = {
   validator: DEFAULT_VALIDATOR_CONFIG,
   relay: DEFAULT_RELAY_CONFIG,
   snapshot: DEFAULT_SNAPSHOT_CONFIG,

--- a/amman/src/validator/init-validator.ts
+++ b/amman/src/validator/init-validator.ts
@@ -91,6 +91,7 @@ export async function initValidator(
     validator,
     detached,
     config,
+    pid: validator.pid!,
   }
 
   // -----------------
@@ -150,4 +151,6 @@ export async function initValidator(
   // Wait for validator to come up and cleanup
   // -----------------
   await waitForValidator(jsonRpcUrl, verifyFees, cleanupConfig)
+
+  return ammanState
 }

--- a/amman/src/validator/init-validator.ts
+++ b/amman/src/validator/init-validator.ts
@@ -91,7 +91,6 @@ export async function initValidator(
     validator,
     detached,
     config,
-    pid: validator.pid!,
   }
 
   // -----------------

--- a/amman/src/validator/solana-validator.ts
+++ b/amman/src/validator/solana-validator.ts
@@ -1,6 +1,7 @@
 import { PersistedAccountInfo } from '@metaplex-foundation/amman-client'
 import { Keypair } from '@solana/web3.js'
 import { ChildProcess, spawn } from 'child_process'
+import { AccountStates } from 'src/accounts/state'
 import { createTemporarySnapshot, SnapshotConfig } from '../assets'
 import { AmmanConfig } from '../types'
 import { canAccessSync } from '../utils/fs'
@@ -174,10 +175,13 @@ export async function restartValidatorWithSnapshot(
  *
  */
 export async function restartValidator(
+  accountStates: AccountStates,
   ammanState: AmmanState,
   config: Required<AmmanConfig>
 ) {
   logDebug('Restarting validator')
+
+  accountStates.paused = true
 
   await killValidatorChild(ammanState.validator)
 
@@ -193,6 +197,7 @@ export async function restartValidator(
     config.validator.verifyFees,
     cleanupConfig
   )
+  accountStates.paused = false
 
   return { args, ...rest }
 }

--- a/amman/src/validator/solana-validator.ts
+++ b/amman/src/validator/solana-validator.ts
@@ -173,7 +173,7 @@ export async function restartValidatorWithSnapshot(
  * handle transactions after it is restarted twice (they time out after 30secs)
  *
  */
-async function restartValidator(
+export async function restartValidator(
   ammanState: AmmanState,
   config: Required<AmmanConfig>
 ) {
@@ -194,5 +194,5 @@ async function restartValidator(
     cleanupConfig
   )
 
-  return { args, cleanupConfig, ...rest }
+  return { args, ...rest }
 }

--- a/amman/src/validator/solana-validator.ts
+++ b/amman/src/validator/solana-validator.ts
@@ -129,6 +129,7 @@ export function killValidatorChild(child: ChildProcess) {
  *
  */
 export async function restartValidatorWithAccountOverrides(
+  accountStates: AccountStates,
   ammanState: AmmanState,
   addresses: string[],
   // Keyed pubkey:label
@@ -145,7 +146,7 @@ export async function restartValidatorWithAccountOverrides(
     )
 
   const config: Required<AmmanConfig> = { ...ammanState.config, snapshot }
-  const res = await restartValidator(ammanState, config)
+  const res = await restartValidator(accountStates, ammanState, config)
 
   await cleanupSnapshotDir()
 
@@ -156,6 +157,7 @@ export async function restartValidatorWithAccountOverrides(
  * Attempts to kill and restart the validator with the given snapshot.
  */
 export async function restartValidatorWithSnapshot(
+  accountStates: AccountStates,
   ammanState: AmmanState,
   snapshotLabel: string
 ) {
@@ -164,7 +166,7 @@ export async function restartValidatorWithSnapshot(
     load: snapshotLabel,
   }
   const config: Required<AmmanConfig> = { ...ammanState.config, snapshot }
-  return restartValidator(ammanState, config)
+  return restartValidator(accountStates, ammanState, config)
 }
 
 /**

--- a/amman/src/validator/types.ts
+++ b/amman/src/validator/types.ts
@@ -1,5 +1,6 @@
 import { Commitment } from '@solana/web3.js'
 import { ChildProcess } from 'child_process'
+import { RelayServer } from 'src/relay/server'
 import { AmmanConfig } from '../types'
 
 /**
@@ -83,4 +84,10 @@ export type AmmanState = {
   config: Required<AmmanConfig>
   validator: ChildProcess
   detached: boolean
+  pid: number
+}
+
+/** @private only used in tests */
+export type AmmanStateInternal = AmmanState & {
+  relayServer?: RelayServer
 }

--- a/amman/src/validator/types.ts
+++ b/amman/src/validator/types.ts
@@ -84,7 +84,6 @@ export type AmmanState = {
   config: Required<AmmanConfig>
   validator: ChildProcess
   detached: boolean
-  pid: number
 }
 
 /** @private only used in tests */

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "build": "yarn build:client && yarn build:amman",
     "build:client": "rimraf amman-client/dist && tsc -p amman-client/tsconfig.json",
     "build:amman": "rimraf amman/dist && tsc -p amman/tsconfig.json",
+    "tests": "yarn build && (cd amman-tests && yarn test)",
     "lint": "(cd amman-client && yarn lint) && (cd amman && yarn lint)",
     "lint:fix": "(cd amman-client && yarn lint:fix) && (cd amman && yarn lint:fix)",
     "doc": "(cd ./amman && yarn doc);",
@@ -11,7 +12,8 @@
   "workspaces": {
     "packages": [
       "amman",
-      "amman-client"
+      "amman-client",
+      "amman-test"
     ]
   },
   "author": "Thorsten Lorenz <thlorenz@gmx.de>",


### PR DESCRIPTION
## Summary

Adding a `restartValidator` request to the relay which keeps amman itself and the relay
running, but stops and starts the solana-test-validator.

This is useful when running multiple tests together and wanting to reset everything between
each test to either an _empty_ genesis state or to whatever snapshot was loaded.

Note that in order to minimize error messages while the validator is restarting, we're pausing the `AccountStates` from querying solana.

In order to be able to test restart and also since it might be useful for others we added the ability to request the validator `pid`.

## Test

In order to verify that this works I added a amman-test package which for now just makes sure
that socket communication for the most basic requests works as well as that we can restart the
validator.

## Remaining

More socket communication tests should be added as well as for the rest client once we have it.

Additionally the restart-validator tests should include cases with snapshots and accounts to
make sure that they are properly reloaded on restart.

Piece by piece we also need to add tests around the other tasks.

Finally all those tests need to run during CI so we need to setup github actions for that as well.
