### PR TITLE
feat: check amman compat when running client requests

### DIFF
--- a/amman-client/package.json
+++ b/amman-client/package.json
@@ -4,6 +4,7 @@
   "description": "Client piece of amman which supports with the running validator, relay and storage.",
   "main": "dist/amman-client.js",
   "types": "dist/amman-client.d.ts",
+  "minAmmanCliVersion": "0.11.0",
   "scripts": {
     "check:publish-ready": "yarn build",
     "preversion": "yarn check:publish-ready",

--- a/amman-client/src/relay/version.ts
+++ b/amman-client/src/relay/version.ts
@@ -1,0 +1,23 @@
+import { AmmanVersion } from './types'
+
+export const MIN_AMMAN_CLI_VERSION_REQUIRED: AmmanVersion =
+  require('../../package.json')
+    .minAmmanCliVersion.split('.')
+    .map((v: string) => parseInt(v))
+
+export function requiredVersionSatisfied(version: AmmanVersion): boolean {
+  const minVersion = MIN_AMMAN_CLI_VERSION_REQUIRED
+  if (version[0] > minVersion[0]) return true
+  if (version[0] < minVersion[0]) return false
+  if (version[1] > minVersion[1]) return true
+  if (version[1] < minVersion[1]) return false
+  return version[2] >= version[2]
+}
+
+export function versionString(version: AmmanVersion): string {
+  return `v${version[0]}.${version[1]}.${version[2]}`
+}
+
+export const ENSURE_VERSION = `Make sure to use amman cli version >=${versionString(
+  MIN_AMMAN_CLI_VERSION_REQUIRED
+)} by updating amman updating it from npm:\nhttps://www.npmjs.com/package/@metaplex-foundation/amman\n`


### PR DESCRIPTION
## Summary

In order to quickly warn the user if the `amman-client` used is incompatible with the `amman`
CLI used due to the latter being out of date a version check is performed.

If this version check fails then an error is raised and printed to the console. 

### Sample Error Message

```
Error: It appears you're using an outdated amman cli version v0.10.0
Make sure to use amman cli version >= v0.11.0 by updating amman updating it from npm:
https://www.npmjs.com/package/@metaplex-foundation/amman
```

### Sample Succes Debug Message Logged

```
amman:relay:debug Verified that v0.11.0 >= v0.11.0. +90ms
```
