### PR TITLE
chore: upgrade web3 and using it to log

### DIFF
--- a/amman-client/package.json
+++ b/amman-client/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@metaplex-foundation/cusper": "^0.0.2",
     "@solana/spl-token-registry": "^0.2.2405",
-    "@solana/web3.js": "^1.55.0",
+    "@solana/web3.js": "^1.63.1",
     "bn.js": "^5.2.1",
     "debug": "^4.3.3",
     "js-sha3": "^0.8.0",

--- a/amman-client/src/asserts/asserts.ts
+++ b/amman-client/src/asserts/asserts.ts
@@ -59,7 +59,10 @@ export function assertTransactionSummary(
 ) {
   const { failed = false } = args
   if (failed) {
-    t.ok(summary.transactionError, 'transaction summary has transaction error')
+    t.ok(
+      summary.transactionError != null,
+      'transaction summary has transaction error'
+    )
   } else {
     t.ok(
       summary.transactionError == null,
@@ -204,7 +207,7 @@ type AssertErrorMatchesOpts<Err> = {
 
 function maybeLogTxUrl(signature?: string) {
   if (signature != null) {
-    logInfo(`Inspect via: ${AMMAN_EXPLORER}#/tx/${signature}`)
+    logInfo(`Inspect via: ${AMMAN_EXPLORER}/#/tx/${signature}`)
   }
 }
 
@@ -269,7 +272,7 @@ export function assertErrorMatches<Err extends Function>(
       maybeLogTxUrl(opts.txSignature)
     } else {
       if (msgRx.test(msg)) {
-        t.ok(`error message ('${msg}') matches ${msgRx.toString()}`)
+        t.ok(true, `error message ('${msg}') matches ${msgRx.toString()}`)
       } else {
         t.fail(`error message ('${msg}') does not match ${msgRx.toString()}`)
         maybeLogTxUrl(opts.txSignature)

--- a/amman/package.json
+++ b/amman/package.json
@@ -56,7 +56,6 @@
     "numeral": "^2.0.6",
     "port-pid": "^0.0.7",
     "socket.io": "^4.4.1",
-    "split2": "^4.1.0",
     "text-table": "^0.2.0",
     "timeago.js": "^4.0.2",
     "ts-essentials": "^9.3.0",

--- a/amman/package.json
+++ b/amman/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@metaplex-foundation/amman-client": "^0.2.0",
     "@solana/spl-token": "^0.2.0",
-    "@solana/web3.js": "^1.43.4",
+    "@solana/web3.js": "^1.63.1",
     "ansi-colors": "^4.1.1",
     "bn.js": "^5.2.0",
     "buffer-hexdump": "^1.0.0",

--- a/amman/src/cli/utils/solana-logs.ts
+++ b/amman/src/cli/utils/solana-logs.ts
@@ -17,15 +17,18 @@ export async function pipeSolanaLogs(amman?: Amman, commitment?: Commitment) {
   connection.onLogs(
     'all',
     async (logs: Logs, _ctx: Context) => {
+      // only include transaction err for last line, otherwise we'd log it for each
       for (let i = 0; i < logs.logs.length; i++) {
         const line = logs.logs[i]
-        const last = i === logs.logs.length - 1
         try {
           // only include transaction err for last line, otherwise we'd log it for each
-          await logLine(logger, line, last ? logs.err : null)
+          await logLine(logger, line, null)
         } catch (err) {
           logTrace('Logger encountered an error', err)
         }
+      }
+      if (logs.err != null) {
+        await logLine(logger, '', logs.err)
       }
     },
     commitment

--- a/amman/src/cli/utils/solana-logs.ts
+++ b/amman/src/cli/utils/solana-logs.ts
@@ -21,7 +21,6 @@ export async function pipeSolanaLogs(amman?: Amman, commitment?: Commitment) {
       for (let i = 0; i < logs.logs.length; i++) {
         const line = logs.logs[i]
         try {
-          // only include transaction err for last line, otherwise we'd log it for each
           await logLine(logger, line, null)
         } catch (err) {
           logTrace('Logger encountered an error', err)

--- a/amman/src/cli/utils/solana-logs.ts
+++ b/amman/src/cli/utils/solana-logs.ts
@@ -1,29 +1,45 @@
 import { Amman, LOCALHOST } from '@metaplex-foundation/amman-client'
+import {
+  Commitment,
+  Connection,
+  Context,
+  Logs,
+  TransactionError,
+} from '@solana/web3.js'
 import colors from 'ansi-colors'
-import { spawn } from 'child_process'
-import split from 'split2'
 import { Cluster, LogMessage, PrettyLogger } from '../../diagnostics/programs'
 import { logTrace } from '../../utils'
 
-export async function pipeSolanaLogs(amman?: Amman) {
+export async function pipeSolanaLogs(amman?: Amman, commitment?: Commitment) {
   const logger = new PrettyLogger(amman)
-  const child = spawn('solana', ['logs', '--url', LOCALHOST], {
-    detached: false,
-    stdio: 'pipe',
-  })
-  for await (const line of child.stdout?.pipe(split())) {
-    try {
-      await logLine(logger, line)
-    } catch (err) {
-      logTrace('Logger encountered an error', err)
-    }
-  }
+  commitment ??= 'confirmed'
+  const connection = new Connection(LOCALHOST, commitment)
+  connection.onLogs(
+    'all',
+    async (logs: Logs, _ctx: Context) => {
+      for (let i = 0; i < logs.logs.length; i++) {
+        const line = logs.logs[i]
+        const last = i === logs.logs.length - 1
+        try {
+          // only include transaction err for last line, otherwise we'd log it for each
+          await logLine(logger, line, last ? logs.err : null)
+        } catch (err) {
+          logTrace('Logger encountered an error', err)
+        }
+      }
+    },
+    commitment
+  )
 }
 
-async function logLine(logger: PrettyLogger, line: string) {
+async function logLine(
+  logger: PrettyLogger,
+  line: string,
+  error: TransactionError | null
+) {
   const { newLogs, newInstruction, newOuterInstruction } = await logger.addLine(
     line,
-    null,
+    error,
     Cluster.Amman
   )
   if (newOuterInstruction) {

--- a/amman/src/diagnostics/programs/log-parser.ts
+++ b/amman/src/diagnostics/programs/log-parser.ts
@@ -157,9 +157,13 @@ export class PrettyLogger {
       }
     }
 
-    // If the instruction's simulation returned an error without any logs then add an empty log entry for Runtime error
-    // For example BpfUpgradableLoader fails without returning any logs for Upgrade instruction with buffer that doesn't exist
-    if (prettyError && this.prettyLogs.length === 0) {
+    // If the instruction's simulation returned an error without any logs then
+    // add an empty log entry for Runtime error For example BpfUpgradableLoader
+    // fails without returning any logs for Upgrade instruction with buffer
+    // that doesn't exist.
+    // However we saw cases where there are logs without the error and we end
+    // not logging the error at all which is worse than logging it twice.
+    if (prettyError != null) {
       this.prettyLogs.push({
         logs: [],
         failed: true,


### PR DESCRIPTION
## Summary

This PR fixes multiple issues around transaction errors.

One is that logs wouldn't always show the error message which was fixed by

- a) using solana web3 connection log events to track and parse log messages
- b) logging the transaction error even if it already might have been logged as part of the transaction logs

The other is that in some cases expected errors weren't set on the transaction property that we queried for this.
Specifically runtime error messages were only present in the logs. Thus we parse them from there if an error regex is passed to `assertError` on the transaction promise.

Fixes #57 
Fixes #58 