### PR TITLE
feat: including transaction labels/signatures when logging assert messages

### DIFF
--- a/amman-client/package.json
+++ b/amman-client/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@metaplex-foundation/cusper": "^0.0.2",
     "@solana/spl-token-registry": "^0.2.2405",
-    "@solana/web3.js": "^1.63.1",
+    "@solana/web3.js": "^1.66.2",
     "bn.js": "^5.2.1",
     "debug": "^4.3.3",
     "js-sha3": "^0.8.0",

--- a/amman-client/src/asserts/asserts.ts
+++ b/amman-client/src/asserts/asserts.ts
@@ -107,7 +107,7 @@ export function assertTransactionSuccess(
     t.fail(`Transaction ('${label}') failed ${errMsg}`)
     logError({ logs: summary.logMessages })
     if (details.txSignature != null) {
-      logInfo(`Inspect via: ${AMMAN_EXPLORER}#/tx/${details.txSignature}`)
+      logInfo(`Inspect via: ${AMMAN_EXPLORER}/#/tx/${details.txSignature}`)
     }
     return
   }
@@ -211,7 +211,7 @@ export function assertContainMessages(
       logError('Failed to find %s inside', msgRx.toString())
       logError(logs.join('\n  '))
       if (opts.txSignature != null) {
-        logInfo(`Inspect via: ${AMMAN_EXPLORER}#/tx/${opts.txSignature}`)
+        logInfo(`Inspect via: ${AMMAN_EXPLORER}/#/tx/${opts.txSignature}`)
       }
     }
 
@@ -224,7 +224,7 @@ export function assertContainMessages(
       t.fail(
         `Transaction logs for '${txLabel}' do not match '${msgRx.toString()}' in ${label}`
       )
-      logInfo(`Inspect via: ${AMMAN_EXPLORER}#/tx/${opts.txSignature}`)
+      logInfo(`Inspect via: ${AMMAN_EXPLORER}/#/tx/${opts.txSignature}`)
     }
   }
 }

--- a/amman-client/src/asserts/asserts.ts
+++ b/amman-client/src/asserts/asserts.ts
@@ -21,6 +21,13 @@ export type Assert = {
 }
 
 /**
+ * Options to pass to asserts to allow providing more diagnostics.
+ *
+ * @property txLabel label of the transaction to include in the error message
+ */
+export type AssertOpts = { txLabel?: string; txSignature?: string }
+
+/**
  * Asserts details about a confirmed transaction
  *
  * @deprecated use {@link assertTransactionSuccess} or {@link assertTransactionError} instead
@@ -76,7 +83,7 @@ export function assertTransactionSummary(
     t.equal(summary.fee, args.fee, 'transaction summary fee matches')
   }
   if (args.msgRxs != null) {
-    assertContainMessages(t, summary.logMessages, args.msgRxs)
+    assertContainMessages(t, summary.logMessages, args.msgRxs, {})
   }
 }
 
@@ -89,12 +96,15 @@ export function assertTransactionSuccess(
   t: Assert,
   details: Pick<ConfirmedTransactionDetails, 'txSummary'> & {
     txSignature?: TransactionSignature
+    txLabel?: string
   },
   msgRxs?: RegExp[]
 ) {
+  const label = details.txLabel ?? details.txSignature ?? 'N/A'
   const summary = details.txSummary
   if (summary.loggedError != null) {
-    t.fail(summary.loggedError.stack ?? summary.loggedError.toString())
+    const errMsg = summary.loggedError.stack ?? summary.loggedError.toString()
+    t.fail(`Transaction ('${label}') failed ${errMsg}`)
     logError({ logs: summary.logMessages })
     if (details.txSignature != null) {
       logInfo(`Inspect via: ${AMMAN_EXPLORER}#/tx/${details.txSignature}`)
@@ -103,10 +113,10 @@ export function assertTransactionSuccess(
   }
   t.ok(
     summary.transactionError == null,
-    'transaction summary has no transaction error'
+    `transaction summary of '${label}' has no transaction error`
   )
   if (msgRxs != null) {
-    assertContainMessages(t, summary.logMessages, msgRxs)
+    assertContainMessages(t, summary.logMessages, msgRxs, details)
   }
 }
 
@@ -128,6 +138,7 @@ export function assertTransactionError<Err extends Function>(
   t: Assert,
   details: Pick<ConfirmedTransactionDetails, 'txSummary'> & {
     txSignature?: TransactionSignature
+    txLabel?: string
   },
   errOrRx?: Err | RegExp,
   msgRx?: RegExp
@@ -156,9 +167,15 @@ export function assertTransactionError<Err extends Function>(
  * @param t
  * @param err error to verify
  * @param msgRxs list of {@link RegExp} which will be matched on the error _message_ or `err.logs`.
+ * @param opts options to customize the assertion diagnostics
  * @category asserts
  */
-export function assertError(t: Assert, err: Error, msgRxs: RegExp[]) {
+export function assertError(
+  t: Assert,
+  err: Error,
+  msgRxs: RegExp[],
+  opts: AssertOpts = {}
+) {
   t.ok(err != null, 'error encountered')
   const errWithLogs = err as Error & { logs?: string[] }
   t.ok(errWithLogs.logs != null, 'error has logs')
@@ -166,7 +183,7 @@ export function assertError(t: Assert, err: Error, msgRxs: RegExp[]) {
     .toString()
     .split('\n')
     .concat(errWithLogs.logs ?? [])
-  assertContainMessages(t, errorMessages, msgRxs)
+  assertContainMessages(t, errorMessages, msgRxs, opts)
 }
 
 /**
@@ -175,6 +192,8 @@ export function assertError(t: Assert, err: Error, msgRxs: RegExp[]) {
  * @param t
  * @param logs containing messages to match
  * @param msgRxs list of {@link RegExp} which will be matched on the {@link logs}.
+ * @param opts options to customize the assertion diagnostics
+ * @param label label of the container we check for messages to include in the error message
  * @category asserts
  * @private
  */
@@ -182,16 +201,31 @@ export function assertContainMessages(
   t: Assert,
   logs: string[],
   msgRxs: RegExp[],
+  opts: AssertOpts,
   label: string = 'log messages'
 ) {
+  const txLabel = opts.txLabel ?? opts.txSignature ?? 'N/A'
   for (const msgRx of msgRxs) {
     const hasMatch = logs.some((x) => msgRx.test(x))
     if (!hasMatch) {
-      console.error('Failed to find %s inside', msgRx.toString())
-      console.error(logs.join('\n  '))
+      logError('Failed to find %s inside', msgRx.toString())
+      logError(logs.join('\n  '))
+      if (opts.txSignature != null) {
+        logInfo(`Inspect via: ${AMMAN_EXPLORER}#/tx/${opts.txSignature}`)
+      }
     }
 
-    t.ok(hasMatch, `match '${msgRx.toString()}' in ${label}`)
+    if (hasMatch) {
+      t.ok(
+        true,
+        `Transaction logs for '${txLabel}' match '${msgRx.toString()}' in ${label}`
+      )
+    } else {
+      t.fail(
+        `Transaction logs for '${txLabel}' do not match '${msgRx.toString()}' in ${label}`
+      )
+      logInfo(`Inspect via: ${AMMAN_EXPLORER}#/tx/${opts.txSignature}`)
+    }
   }
 }
 

--- a/amman-client/src/transactions/confirmed-transaction-assertable-promise.ts
+++ b/amman-client/src/transactions/confirmed-transaction-assertable-promise.ts
@@ -70,8 +70,8 @@ export class ConfirmedTransactionAssertablePromise
       ) => void,
       reject: (reason?: any) => void
     ) => void,
-    // It seems that this constructor is invoked from outside our code, possibly due to being a promise
-    // In that case this seconde param is not passed, so we need to account for that
+    // It seems that this constructor is invoked from outside our code, possibly due to being a promise.
+    // In that case this second param is not passed, so we need to account for that.
     opts?: ConfirmedTransactionAssertablePromiseOpts
   ) {
     super(executor)

--- a/amman-client/src/transactions/confirmed-transaction-assertable-promise.ts
+++ b/amman-client/src/transactions/confirmed-transaction-assertable-promise.ts
@@ -43,6 +43,11 @@ await txHandler.sendAndConfirmTransaction(
   signers,
 ).assertNone()`
 
+type ConfirmedTransactionAssertablePromiseOpts = {
+  requireAssert: boolean
+  transactionLabel?: string
+}
+
 /**
  * A {@link Promise} that is returned by {@link PayerTransactionHandler} `sendAndConfirmTransaction`.
  * Aside from regular promise functionality it includes `assert` methods that
@@ -54,6 +59,7 @@ export class ConfirmedTransactionAssertablePromise
   implements ConfirmedTransactionAsserts
 {
   private calledAssert: boolean
+  private transactionLabel?: string
   private errorStack?: string
   constructor(
     executor: (
@@ -64,12 +70,15 @@ export class ConfirmedTransactionAssertablePromise
       ) => void,
       reject: (reason?: any) => void
     ) => void,
-    requireAssert: boolean
+    // It seems that this constructor is invoked from outside our code, possibly due to being a promise
+    // In that case this seconde param is not passed, so we need to account for that
+    opts?: ConfirmedTransactionAssertablePromiseOpts
   ) {
     super(executor)
     this.errorStack = new Error().stack?.split('\n').slice(2).join('\n')
+    this.transactionLabel = opts?.transactionLabel
     this.calledAssert = false
-    if (requireAssert) {
+    if (opts?.requireAssert ?? false) {
       setImmediate(() => {
         if (!this.calledAssert) {
           throw new Error(
@@ -94,7 +103,11 @@ ${this.errorStack}`
   async assertSuccess(t: Assert, msgRxs?: RegExp[]) {
     this.calledAssert = true
     const details = await this
-    assertTransactionSuccess(t, details, msgRxs)
+    assertTransactionSuccess(
+      t,
+      { ...details, txLabel: this.transactionLabel },
+      msgRxs
+    )
     return details
   }
 
@@ -114,7 +127,12 @@ ${this.errorStack}`
   ) {
     this.calledAssert = true
     const details = await this
-    assertTransactionError(t, details, errOrRx, msgRx)
+    assertTransactionError(
+      t,
+      { ...details, txLabel: this.transactionLabel },
+      errOrRx,
+      msgRx
+    )
     return details
   }
 
@@ -135,21 +153,27 @@ ${this.errorStack}`
     this.calledAssert = true
     try {
       const details = await this
+      const label = this.transactionLabel ?? details.txSignature
       t.fail(
-        'expected to throw an error when sending/confirming the transaction'
+        `Transaction '${label}' was expected to throw an error when sending/confirming the transaction but it succeeded.`
       )
       return details
     } catch (err: any) {
       const error = typeof errOrRx === 'function' ? errOrRx : undefined
       const rx = typeof errOrRx === 'function' ? msgRx : errOrRx
+      const label = this.transactionLabel ?? 'N/A'
       if (error != null) {
-        t.ok(err instanceof error, `error is of type ${error.name}`)
+        t.ok(
+          err instanceof error,
+          `Error found inside transaction '${label}' is of type ${error.name}`
+        )
       }
       if (rx != null) {
         assertContainMessages(
           t,
           err.toString().split('\n'),
           [rx],
+          { txLabel: this.transactionLabel },
           'error message'
         )
       }
@@ -171,6 +195,7 @@ ${this.errorStack}`
       t,
       details.txSummary.logMessages,
       msgRxs,
+      { txLabel: this.transactionLabel, txSignature: details.txSignature },
       'log messages'
     )
   }

--- a/amman-client/src/transactions/transaction-checker.ts
+++ b/amman-client/src/transactions/transaction-checker.ts
@@ -8,6 +8,7 @@ import { strict as assert } from 'assert'
 import {
   Assert,
   assertContainMessages,
+  AssertOpts,
   assertTransactionError,
   assertTransactionSuccess,
 } from '../asserts/asserts'
@@ -103,20 +104,28 @@ export class TransactionChecker {
    * This does not check for success or failure of the transaction.
    *
    * @param msgRxs it is verified that the logs match all these {@link RegExp}es
+   * @param opts options to customize the assertion diagnostics
    * @category transactions
    * @category asserts
    */
   async assertLogs(
     t: Assert,
     txSignature: TransactionSignature,
-    msgRxs: RegExp[]
+    msgRxs: RegExp[],
+    opts: AssertOpts
   ) {
     const { txSummary, txConfirmed } = await fetchTransactionSummary(
       this.connection,
       txSignature,
       this.errorResolver
     )
-    assertContainMessages(t, txSummary.logMessages, msgRxs, 'log messages')
+    assertContainMessages(
+      t,
+      txSummary.logMessages,
+      msgRxs,
+      opts,
+      'log messages'
+    )
     return new TransactionCheckerAssertReturn({ txSummary, txConfirmed })
   }
 }

--- a/amman-client/src/transactions/transaction-handler.ts
+++ b/amman-client/src/transactions/transaction-handler.ts
@@ -99,7 +99,10 @@ export class PayerTransactionHandler implements TransactionHandler {
           reject(err)
         }
       },
-      confirmOptions.skipPreflight ?? false
+      {
+        requireAssert: confirmOptions.skipPreflight ?? false,
+        transactionLabel: addressLabel,
+      }
     )
   }
 }

--- a/amman-client/src/transactions/types.ts
+++ b/amman-client/src/transactions/types.ts
@@ -11,7 +11,7 @@ import {
   TransactionResponse,
   TransactionSignature,
 } from '@solana/web3.js'
-import { Assert, assertContainMessages } from '../asserts/asserts'
+import { Assert, assertContainMessages, AssertOpts } from '../asserts/asserts'
 
 export type { MaybeErrorWithCode } from '@metaplex-foundation/cusper'
 
@@ -84,9 +84,16 @@ export class ConfirmedTransactionDetails {
    * Call this if to assert that the log messages match a given set of regular expressions.
    *
    * @param msgRxs it is verified that the logs match all these {@link RegExp}es
+   * @param opts options to customize the assertion diagnostics
    */
-  async assertLogs(t: Assert, msgRxs: RegExp[]) {
-    assertContainMessages(t, this.txSummary.logMessages, msgRxs, 'log messages')
+  async assertLogs(t: Assert, msgRxs: RegExp[], opts: AssertOpts) {
+    assertContainMessages(
+      t,
+      this.txSummary.logMessages,
+      msgRxs,
+      opts,
+      'log messages'
+    )
   }
 }
 


### PR DESCRIPTION
- chore: bump web3 to latest
- feat: including transaction labels in assert messages

FIXES: #56
