### PR TITLE
fix build fail issue on amman/src/cli/amman.ts caused by function cal…

### DIFF
--- a/amman/src/cli/amman.ts
+++ b/amman/src/cli/amman.ts
@@ -4,7 +4,7 @@ import {
   AMMAN_STORAGE_PORT,
   Amman,
 } from '@metaplex-foundation/amman-client'
-import { Connection } from '@solana/web3.js'
+import { Commitment, Connection } from '@solana/web3.js'
 import { strict as assert } from 'assert'
 import { execSync as exec } from 'child_process'
 import path from 'path'
@@ -245,13 +245,13 @@ async function main() {
           destination != null,
           'public key string or keypair file is required'
         )
-        assertCommitment(commitment)
+        assertCommitment(commitment as string)
 
         const { connection } = await handleAirdropCommand(
           destination,
           amount,
-          label!,
-          commitment
+          label! as string,
+          commitment as Commitment
         )
 
         await closeConnection(connection, true)
@@ -296,7 +296,7 @@ async function main() {
       )
 
       const { connection, rendered, savedAccountPath } =
-        await handleAccountCommand(address, includeTx, save)
+        await handleAccountCommand(address, includeTx as boolean, save as boolean)
 
       console.log(rendered)
 
@@ -328,7 +328,7 @@ async function main() {
     // run
     // -----------------
     case 'run': {
-      let labels: string | string[] = args.label ?? []
+      let labels: string | string[] = args.label as string | string[] ?? []
       if (!Array.isArray(labels)) {
         labels = [labels]
       }
@@ -343,8 +343,8 @@ async function main() {
         const { stdout, stderr } = await handleRunCommand(
           labels,
           cmdArgs,
-          txOnly,
-          accOnly
+          txOnly as boolean,
+          accOnly as boolean
         )
         console.error(stderr)
         console.log(stdout)


### PR DESCRIPTION
Here's the fix for the issue when we run `yarn build`. Fixing this would help the newbies to test easily. @thlorenz 

```
$ yarn build
yarn run v1.22.19
$ yarn build:client && yarn build:amman
$ rimraf amman-client/dist && tsc -p amman-client/tsconfig.json
$ rimraf amman/dist && tsc -p amman/tsconfig.json
amman/src/cli/amman.ts:248:26 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.

248         assertCommitment(commitment)
                             ~~~~~~~~~~

amman/src/cli/amman.ts:253:11 - error TS2345: Argument of type '{}' is not assignable to parameter of type 'string'.

253           label!,
              ~~~~~~

amman/src/cli/amman.ts:299:45 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'boolean'.

299         await handleAccountCommand(address, includeTx, save)
                                                ~~~~~~~~~

amman/src/cli/amman.ts:331:11 - error TS2322: Type '{}' is not assignable to type 'string | string[]'.

331       let labels: string | string[] = args.label ?? []
              ~~~~~~

amman/src/cli/amman.ts:346:11 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'boolean'.

346           txOnly,
              ~~~~~~


Found 5 errors in the same file, starting at: amman/src/cli/amman.ts:248

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```